### PR TITLE
Show sidebar submodules on hover

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,621 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ecopilot – Prototype RSE</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body data-theme="light">
+    <div class="app" id="app-root">
+      <aside class="sidebar" id="app-sidebar">
+        <div class="sidebar__top">
+          <div class="sidebar__brand">
+            <span class="sidebar__logo" aria-hidden="true">🌱</span>
+            <div class="sidebar__brand-text">
+              <span class="sidebar__brand-title" data-i18n="brand.title">Ecopilot</span>
+              <span class="sidebar__brand-subtitle" data-i18n="brand.subtitle">Pilotage ESG</span>
+            </div>
+          </div>
+          <button
+            class="sidebar__collapse"
+            type="button"
+            data-action="collapse-sidebar"
+            aria-expanded="true"
+          >
+            <span class="sidebar__collapse-icon" aria-hidden="true">⮜</span>
+            <span class="sidebar__collapse-label" data-i18n="actions.sidebar.collapse">Replier le menu</span>
+          </button>
+        </div>
+        <div class="sidebar__welcome">
+          <span class="sidebar__welcome-title" data-i18n="welcome.title">Bienvenue</span>
+          <span class="sidebar__welcome-user" data-i18n="welcome.user">Utilisateur</span>
+        </div>
+        <nav class="sidebar__menu" aria-label="Navigation principale">
+          <div class="sidebar__group">
+            <p class="sidebar__heading" data-i18n="nav.sections.overview">Vue générale</p>
+            <div class="nav-item-wrapper">
+              <button class="nav-item is-active" type="button" data-target="dashboard">
+                <span class="nav-item__bullet" aria-hidden="true">●</span>
+                <span class="nav-item__label" data-i18n="nav.overview.label">Main KPIs</span>
+              </button>
+            </div>
+          </div>
+          <div class="sidebar__group">
+            <p class="sidebar__heading" data-i18n="nav.sections.database">Base de données</p>
+            <div class="nav-item-wrapper">
+              <button class="nav-item" type="button" data-target="data-entry">
+                <span class="nav-item__bullet" aria-hidden="true">●</span>
+                <span class="nav-item__label" data-i18n="nav.dataEntry.label">Saisie de données</span>
+              </button>
+              <div class="nav-item__popover" role="group">
+                <p class="nav-item__popover-title" data-i18n="nav.dataEntry.submodules.title">Sous-modules</p>
+                <ul class="nav-item__popover-list">
+                  <li data-i18n="nav.dataEntry.submodules.items.business">BU</li>
+                  <li data-i18n="nav.dataEntry.submodules.items.activity">Activité</li>
+                  <li data-i18n="nav.dataEntry.submodules.items.filters">Filtres</li>
+                  <li data-i18n="nav.dataEntry.submodules.items.sites">Sites</li>
+                </ul>
+                <p class="nav-item__popover-note" data-i18n="nav.popover.hint">Survoler pour explorer le module complet.</p>
+              </div>
+            </div>
+            <div class="nav-item-wrapper">
+              <button class="nav-item" type="button" data-target="filters">
+                <span class="nav-item__bullet" aria-hidden="true">●</span>
+                <span class="nav-item__label" data-i18n="nav.filters.label">Filtres &amp; vues</span>
+              </button>
+              <div class="nav-item__popover" role="group">
+                <p class="nav-item__popover-title" data-i18n="nav.filters.submodules.title">Sous-modules</p>
+                <ul class="nav-item__popover-list">
+                  <li data-i18n="nav.filters.submodules.items.global">Vue globale</li>
+                  <li data-i18n="nav.filters.submodules.items.business">Vue BU</li>
+                  <li data-i18n="nav.filters.submodules.items.site">Vue site</li>
+                  <li data-i18n="nav.filters.submodules.items.saved">Filtres enregistrés</li>
+                </ul>
+                <p class="nav-item__popover-note" data-i18n="nav.popover.hint">Survoler pour explorer le module complet.</p>
+              </div>
+            </div>
+            <div class="nav-item-wrapper">
+              <button class="nav-item" type="button" data-target="activity">
+                <span class="nav-item__bullet" aria-hidden="true">●</span>
+                <span class="nav-item__label" data-i18n="nav.activity.label">Activité &amp; suivi</span>
+              </button>
+              <div class="nav-item__popover" role="group">
+                <p class="nav-item__popover-title" data-i18n="nav.activity.submodules.title">Sous-modules</p>
+                <ul class="nav-item__popover-list">
+                  <li data-i18n="nav.activity.submodules.items.workflow">Workflows</li>
+                  <li data-i18n="nav.activity.submodules.items.notifications">Notifications</li>
+                  <li data-i18n="nav.activity.submodules.items.history">Historique</li>
+                </ul>
+                <p class="nav-item__popover-note" data-i18n="nav.popover.hint">Survoler pour explorer le module complet.</p>
+              </div>
+            </div>
+          </div>
+          <div class="sidebar__group">
+            <p class="sidebar__heading" data-i18n="nav.sections.modules">Modules d’analyse</p>
+            <div class="nav-item-wrapper">
+              <button class="nav-item" type="button" data-target="carbon">
+                <span class="nav-item__bullet" aria-hidden="true">●</span>
+                <span class="nav-item__label" data-i18n="nav.carbon.label">Empreinte carbone</span>
+              </button>
+              <div class="nav-item__popover" role="group">
+                <p class="nav-item__popover-title" data-i18n="nav.carbon.submodules.title">Focus</p>
+                <ul class="nav-item__popover-list">
+                  <li data-i18n="nav.carbon.submodules.items.scope1">Scope 1</li>
+                  <li data-i18n="nav.carbon.submodules.items.scope2">Scope 2</li>
+                  <li data-i18n="nav.carbon.submodules.items.scope3">Scope 3</li>
+                  <li data-i18n="nav.carbon.submodules.items.actionPlans">Plans d’action</li>
+                </ul>
+                <p class="nav-item__popover-note" data-i18n="nav.popover.hint">Survoler pour explorer le module complet.</p>
+              </div>
+            </div>
+            <div class="nav-item-wrapper">
+              <button class="nav-item" type="button" data-target="energy">
+                <span class="nav-item__bullet" aria-hidden="true">●</span>
+                <span class="nav-item__label" data-i18n="nav.energy.label">Gestion de l’énergie</span>
+              </button>
+              <div class="nav-item__popover" role="group">
+                <p class="nav-item__popover-title" data-i18n="nav.energy.submodules.title">Focus</p>
+                <ul class="nav-item__popover-list">
+                  <li data-i18n="nav.energy.submodules.items.consumption">Consommations</li>
+                  <li data-i18n="nav.energy.submodules.items.optimisation">Optimisation</li>
+                  <li data-i18n="nav.energy.submodules.items.alerts">Alertes</li>
+                </ul>
+                <p class="nav-item__popover-note" data-i18n="nav.popover.hint">Survoler pour explorer le module complet.</p>
+              </div>
+            </div>
+            <div class="nav-item-wrapper">
+              <button class="nav-item" type="button" data-target="social">
+                <span class="nav-item__bullet" aria-hidden="true">●</span>
+                <span class="nav-item__label" data-i18n="nav.social.label">Social &amp; sociétal</span>
+              </button>
+              <div class="nav-item__popover" role="group">
+                <p class="nav-item__popover-title" data-i18n="nav.social.submodules.title">Focus</p>
+                <ul class="nav-item__popover-list">
+                  <li data-i18n="nav.social.submodules.items.engagement">Engagement</li>
+                  <li data-i18n="nav.social.submodules.items.diversity">Diversité</li>
+                  <li data-i18n="nav.social.submodules.items.qvt">Qualité de vie au travail</li>
+                </ul>
+                <p class="nav-item__popover-note" data-i18n="nav.popover.hint">Survoler pour explorer le module complet.</p>
+              </div>
+            </div>
+            <div class="nav-item-wrapper">
+              <button class="nav-item" type="button" data-target="governance">
+                <span class="nav-item__bullet" aria-hidden="true">●</span>
+                <span class="nav-item__label" data-i18n="nav.governance.label">Gouvernance</span>
+              </button>
+              <div class="nav-item__popover" role="group">
+                <p class="nav-item__popover-title" data-i18n="nav.governance.submodules.title">Focus</p>
+                <ul class="nav-item__popover-list">
+                  <li data-i18n="nav.governance.submodules.items.comite">Comités</li>
+                  <li data-i18n="nav.governance.submodules.items.risk">Risques</li>
+                  <li data-i18n="nav.governance.submodules.items.compliance">Conformité</li>
+                </ul>
+                <p class="nav-item__popover-note" data-i18n="nav.popover.hint">Survoler pour explorer le module complet.</p>
+              </div>
+            </div>
+          </div>
+          <div class="sidebar__group">
+            <p class="sidebar__heading" data-i18n="nav.sections.reporting">Reporting</p>
+            <div class="nav-item-wrapper">
+              <button class="nav-item" type="button" data-target="annual-report">
+                <span class="nav-item__bullet" aria-hidden="true">●</span>
+                <span class="nav-item__label" data-i18n="nav.annual.label">Rapport annuel RSE</span>
+              </button>
+              <div class="nav-item__popover" role="group">
+                <p class="nav-item__popover-title" data-i18n="nav.annual.submodules.title">Livrables</p>
+                <ul class="nav-item__popover-list">
+                  <li data-i18n="nav.annual.submodules.items.structure">Structure du rapport</li>
+                  <li data-i18n="nav.annual.submodules.items.sources">Sources de données</li>
+                  <li data-i18n="nav.annual.submodules.items.validation">Validation</li>
+                </ul>
+                <p class="nav-item__popover-note" data-i18n="nav.popover.hint">Survoler pour explorer le module complet.</p>
+              </div>
+            </div>
+            <div class="nav-item-wrapper">
+              <button class="nav-item" type="button" data-target="performance-report">
+                <span class="nav-item__bullet" aria-hidden="true">●</span>
+                <span class="nav-item__label" data-i18n="nav.performance.label">Rapport de performance</span>
+              </button>
+              <div class="nav-item__popover" role="group">
+                <p class="nav-item__popover-title" data-i18n="nav.performance.submodules.title">Livrables</p>
+                <ul class="nav-item__popover-list">
+                  <li data-i18n="nav.performance.submodules.items.comparative">Tableaux comparatifs</li>
+                  <li data-i18n="nav.performance.submodules.items.exports">Exports</li>
+                  <li data-i18n="nav.performance.submodules.items.sharing">Partage</li>
+                </ul>
+                <p class="nav-item__popover-note" data-i18n="nav.popover.hint">Survoler pour explorer le module complet.</p>
+              </div>
+            </div>
+          </div>
+          <div class="sidebar__group">
+            <p class="sidebar__heading" data-i18n="nav.sections.parameters">Paramètres</p>
+            <div class="nav-item-wrapper">
+              <button class="nav-item" type="button" data-target="parameters">
+                <span class="nav-item__bullet" aria-hidden="true">●</span>
+                <span class="nav-item__label" data-i18n="nav.parameters.label">Administration</span>
+              </button>
+              <div class="nav-item__popover" role="group">
+                <p class="nav-item__popover-title" data-i18n="nav.parameters.submodules.title">Gestion</p>
+                <ul class="nav-item__popover-list">
+                  <li data-i18n="nav.parameters.submodules.items.users">Utilisateurs</li>
+                  <li data-i18n="nav.parameters.submodules.items.security">Sécurité</li>
+                  <li data-i18n="nav.parameters.submodules.items.settings">Paramètres globaux</li>
+                </ul>
+                <p class="nav-item__popover-note" data-i18n="nav.popover.hint">Survoler pour explorer le module complet.</p>
+              </div>
+            </div>
+          </div>
+        </nav>
+        <footer class="sidebar__footer">
+          <button class="logout-button" type="button">
+            <span class="logout-button__icon" aria-hidden="true">⇦</span>
+            <span class="logout-button__label" data-i18n="buttons.logout">Déconnexion</span>
+          </button>
+        </footer>
+      </aside>
+      <main class="main" id="app-main">
+        <header class="topbar">
+          <div class="topbar__breadcrumbs">
+            <span class="breadcrumb" data-i18n="breadcrumbs.home">Accueil</span>
+            <span class="breadcrumb__divider" aria-hidden="true">/</span>
+            <span class="breadcrumb breadcrumb--current" data-role="current-section">Main KPIs</span>
+          </div>
+          <div class="topbar__actions">
+            <div class="language-switch" role="group" aria-label="Choix de la langue">
+              <button class="language-switch__btn is-active" type="button" data-lang="fr" aria-pressed="true">FR</button>
+              <button class="language-switch__btn" type="button" data-lang="en" aria-pressed="false">EN</button>
+            </div>
+            <button class="theme-switch" type="button" data-action="toggle-theme" aria-pressed="false">
+              <span class="theme-switch__icon" aria-hidden="true">🌙</span>
+              <span class="theme-switch__label" data-i18n="actions.theme.dark">Mode sombre</span>
+            </button>
+            <div class="user-badge" role="status">
+              <span class="user-badge__role" data-i18n="user.role">Admin</span>
+              <span class="user-badge__status" data-i18n="user.status">Connecté</span>
+            </div>
+          </div>
+        </header>
+
+        <section class="view is-active" id="dashboard">
+          <header class="view__header">
+            <h1 class="view__title" data-role="section-title" data-i18n="sections.dashboard.title">
+              Main KPIs, graphiques &amp; indicateurs
+            </h1>
+            <p class="view__intro" data-i18n="sections.dashboard.intro">
+              Une page d’accueil pensée pour donner immédiatement la tendance ESG, accéder aux modules clés et guider l’utilisateur vers les actions prioritaires.
+            </p>
+          </header>
+          <div class="overview-grid">
+            <article class="overview-column">
+              <h2 class="overview-column__title" data-i18n="sections.dashboard.parameters.title">Paramètres</h2>
+              <p class="overview-column__note" data-i18n="sections.dashboard.parameters.note">Administration globale par l’organisation cliente.</p>
+              <ul class="overview-list">
+                <li data-i18n="sections.dashboard.parameters.items.profile">Profil</li>
+                <li data-i18n="sections.dashboard.parameters.items.organization">Organisation</li>
+                <li data-i18n="sections.dashboard.parameters.items.subscription">Abonnement</li>
+                <li data-i18n="sections.dashboard.parameters.items.notifications">Notifications</li>
+                <li data-i18n="sections.dashboard.parameters.items.objectives">Objectifs</li>
+              </ul>
+            </article>
+            <article class="overview-column">
+              <h2 class="overview-column__title" data-i18n="sections.dashboard.modules.title">Modules</h2>
+              <p class="overview-column__note" data-i18n="sections.dashboard.modules.note">Accès direct aux flux métiers.</p>
+              <ul class="overview-list">
+                <li data-i18n="sections.dashboard.modules.items.energy">Gestion de l’énergie</li>
+                <li data-i18n="sections.dashboard.modules.items.carbon">Empreinte carbone</li>
+                <li data-i18n="sections.dashboard.modules.items.social">Sociale &amp; sociétale</li>
+                <li data-i18n="sections.dashboard.modules.items.governance">Gouvernance &amp; risques</li>
+              </ul>
+            </article>
+            <article class="overview-column">
+              <h2 class="overview-column__title" data-i18n="sections.dashboard.alignment.title">Alignement RSE</h2>
+              <p class="overview-column__note" data-i18n="sections.dashboard.alignment.note">Suivi du niveau de couverture des référentiels.</p>
+              <ul class="overview-list overview-list--tags">
+                <li data-i18n="sections.dashboard.alignment.items.gri">GRI</li>
+                <li data-i18n="sections.dashboard.alignment.items.odds">ODD</li>
+                <li data-i18n="sections.dashboard.alignment.items.csrd">CSRD</li>
+                <li data-i18n="sections.dashboard.alignment.items.iso">ISO 26000</li>
+              </ul>
+            </article>
+            <article class="overview-column">
+              <h2 class="overview-column__title" data-i18n="sections.dashboard.main.title">Main KPIs</h2>
+              <p class="overview-column__note" data-i18n="sections.dashboard.main.note">Sélection personnalisée par rôle.</p>
+              <ul class="overview-list">
+                <li data-i18n="sections.dashboard.main.items.primary">Indicateurs prioritaires</li>
+                <li data-i18n="sections.dashboard.main.items.secondary">Graphiques dynamiques</li>
+                <li data-i18n="sections.dashboard.main.items.custom">Widgets personnalisés</li>
+              </ul>
+              <div class="plus-grid">
+                <div class="plus-card">
+                  <span aria-hidden="true">＋</span>
+                  <span data-i18n="sections.dashboard.main.placeholder">Ajouter un module de visualisation</span>
+                </div>
+              </div>
+            </article>
+          </div>
+          <p class="view__note" data-i18n="sections.dashboard.note">
+            NB : les sous-modules s’affichent automatiquement selon les droits et modules activés.
+          </p>
+        </section>
+
+        <section class="view" id="data-entry">
+          <header class="view__header">
+            <h1 class="view__title" data-role="section-title" data-i18n="sections.dataEntry.title">Saisie de données</h1>
+            <p class="view__intro" data-i18n="sections.dataEntry.intro">
+              Workflow collaboratif depuis la collecte terrain jusqu’à la consolidation groupe.
+            </p>
+          </header>
+          <div class="card-grid">
+            <article class="info-card">
+              <h2 data-i18n="sections.dataEntry.steps.title">Étapes clés</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.dataEntry.steps.items.collect">Collecte : formulaires normalisés, imports Excel assistés.</li>
+                <li data-i18n="sections.dataEntry.steps.items.validate">Validation : contrôles automatiques et revue du Super User.</li>
+                <li data-i18n="sections.dataEntry.steps.items.approve">Approbation : verrouillage, horodatage et envoi vers les indicateurs.</li>
+              </ul>
+            </article>
+            <article class="info-card">
+              <h2 data-i18n="sections.dataEntry.controls.title">Contrôles &amp; traçabilité</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.dataEntry.controls.items.traceability">Historique complet des contributions par rôle.</li>
+                <li data-i18n="sections.dataEntry.controls.items.version">Versionning des campagnes mensuelles / trimestrielles.</li>
+                <li data-i18n="sections.dataEntry.controls.items.audit">Journal d’audit exportable pour les commissaires.</li>
+              </ul>
+            </article>
+            <article class="info-card">
+              <h2 data-i18n="sections.dataEntry.integrations.title">Intégrations</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.dataEntry.integrations.items.internal">Connexion aux ERP internes (SAP, Oracle, Sage…).</li>
+                <li data-i18n="sections.dataEntry.integrations.items.external">Imports ponctuels depuis bases externes ou prestataires.</li>
+                <li data-i18n="sections.dataEntry.integrations.items.apis">API sécurisée pour industrialiser les synchronisations.</li>
+              </ul>
+            </article>
+          </div>
+          <div class="callout" role="note" data-i18n="sections.dataEntry.callout">
+            Un modèle de langage embarqué propose des recommandations qualité et suggère des valeurs lorsqu’une donnée manque.
+          </div>
+        </section>
+
+        <section class="view" id="filters">
+          <header class="view__header">
+            <h1 class="view__title" data-role="section-title" data-i18n="sections.filters.title">Filtres &amp; vues</h1>
+            <p class="view__intro" data-i18n="sections.filters.intro">
+              Affinez l’analyse en croisant les périmètres métiers, temporels et géographiques.
+            </p>
+          </header>
+          <div class="card-grid">
+            <article class="info-card">
+              <h2 data-i18n="sections.filters.matrix.title">Axes de filtrage</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.filters.matrix.items.period">Période : mois, trimestre, année, multi-années.</li>
+                <li data-i18n="sections.filters.matrix.items.scope">Périmètre : groupe, BU, site, fournisseur.</li>
+                <li data-i18n="sections.filters.matrix.items.activity">Activité : processus, projets, portefeuille d’initiatives.</li>
+                <li data-i18n="sections.filters.matrix.items.impact">Impact : environnemental, social, gouvernance.</li>
+              </ul>
+            </article>
+            <article class="info-card">
+              <h2 data-i18n="sections.filters.usage.title">Cas d’usage</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.filters.usage.items.snapshots">Créer des vues instantanées pour les comités.</li>
+                <li data-i18n="sections.filters.usage.items.comparisons">Comparer N vs N-1 ou objectif vs réalisé.</li>
+                <li data-i18n="sections.filters.usage.items.alerts">Sauvegarder un filtre et recevoir une alerte en cas d’écart.</li>
+              </ul>
+            </article>
+          </div>
+          <p class="view__note" data-i18n="sections.filters.note">
+            Les filtres peuvent être sauvegardés, partagés ou utilisés pour générer automatiquement un rapport.
+          </p>
+        </section>
+
+        <section class="view" id="activity">
+          <header class="view__header">
+            <h1 class="view__title" data-role="section-title" data-i18n="sections.activity.title">Activité &amp; suivi</h1>
+            <p class="view__intro" data-i18n="sections.activity.intro">
+              Pilotage quotidien des actions et notifications issues des modules.
+            </p>
+          </header>
+          <div class="card-grid">
+            <article class="info-card">
+              <h2 data-i18n="sections.activity.timeline.title">Journal d’activité</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.activity.timeline.items.tasks">Tâches assignées par module et niveau de priorité.</li>
+                <li data-i18n="sections.activity.timeline.items.changelog">Historique des modifications avec commentaires.</li>
+                <li data-i18n="sections.activity.timeline.items.comments">Fil de discussion entre contributeurs et managers.</li>
+              </ul>
+            </article>
+            <article class="info-card">
+              <h2 data-i18n="sections.activity.security.title">Gouvernance</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.activity.security.items.roles">Droits différenciés : Admin, Super User, Agent de saisie.</li>
+                <li data-i18n="sections.activity.security.items.approvals">Workflow d’approbation configurable par module.</li>
+                <li data-i18n="sections.activity.security.items.archives">Archivage automatique des campagnes terminées.</li>
+              </ul>
+            </article>
+          </div>
+          <div class="callout" role="note" data-i18n="sections.activity.callout">
+            Un tableau de bord de notifications consolide les alertes critiques pour garder la maîtrise des délais.
+          </div>
+        </section>
+
+        <section class="view" id="carbon">
+          <header class="view__header">
+            <h1 class="view__title" data-role="section-title" data-i18n="sections.carbon.title">Empreinte carbone</h1>
+            <p class="view__intro" data-i18n="sections.carbon.intro">
+              Piloter les émissions sur les scopes 1, 2 et 3 avec une vision budgétaire.
+            </p>
+          </header>
+          <div class="card-grid">
+            <article class="info-card">
+              <h2 data-i18n="sections.carbon.focus.title">Périmètre &amp; facteurs</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.carbon.focus.items.scopes">Calcul automatisé des scopes 1, 2 et 3 avec facteurs certifiés.</li>
+                <li data-i18n="sections.carbon.focus.items.factors">Mise à jour des facteurs ADEME, DEFRA, IEA et facteurs maison.</li>
+                <li data-i18n="sections.carbon.focus.items.trajectory">Construction de trajectoires SBTi et budgets carbone par BU.</li>
+              </ul>
+            </article>
+            <article class="info-card">
+              <h2 data-i18n="sections.carbon.outputs.title">Restitution</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.carbon.outputs.items.reporting">Exports conformes CSRD, CDP, BEGES, label bas carbone.</li>
+                <li data-i18n="sections.carbon.outputs.items.alerts">Alertes sur dérives d’intensité ou ruptures de données.</li>
+                <li data-i18n="sections.carbon.outputs.items.actions">Plan d’actions bas carbone avec suivi ROI &amp; co-bénéfices.</li>
+              </ul>
+            </article>
+          </div>
+          <p class="view__note" data-i18n="sections.carbon.note">
+            Intégration possible avec des capteurs IoT et plateformes fournisseurs pour enrichir le scope 3.
+          </p>
+        </section>
+
+        <section class="view" id="energy">
+          <header class="view__header">
+            <h1 class="view__title" data-role="section-title" data-i18n="sections.energy.title">Gestion de l’énergie</h1>
+            <p class="view__intro" data-i18n="sections.energy.intro">
+              Suivre les consommations, mesurer l’intensité énergétique et piloter la sobriété.
+            </p>
+          </header>
+          <div class="card-grid">
+            <article class="info-card">
+              <h2 data-i18n="sections.energy.monitoring.title">Suivi</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.energy.monitoring.items.consumption">Consolidation multi-énergies et visualisation des pics.</li>
+                <li data-i18n="sections.energy.monitoring.items.intensity">Indicateurs d’intensité par m², unité produite ou site.</li>
+                <li data-i18n="sections.energy.monitoring.items.investments">Suivi des investissements efficacité et de leur ROI.</li>
+              </ul>
+            </article>
+            <article class="info-card">
+              <h2 data-i18n="sections.energy.optimisation.title">Optimisation</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.energy.optimisation.items.plan">Plan de sobriété avec jalons et responsables.</li>
+                <li data-i18n="sections.energy.optimisation.items.projects">Portefeuille de projets (ISO 50001, CEE, relamping…).</li>
+                <li data-i18n="sections.energy.optimisation.items.budget">Pilotage budgétaire : CAPEX, OPEX, certificats d’économie.</li>
+              </ul>
+            </article>
+          </div>
+          <p class="view__note" data-i18n="sections.energy.note">
+            Des connecteurs télérelève permettent d’automatiser la collecte en quasi temps réel.
+          </p>
+        </section>
+
+        <section class="view" id="social">
+          <header class="view__header">
+            <h1 class="view__title" data-role="section-title" data-i18n="sections.social.title">Social &amp; sociétal</h1>
+            <p class="view__intro" data-i18n="sections.social.intro">
+              Mesurer l’engagement des collaborateurs et l’impact des actions sociétales.
+            </p>
+          </header>
+          <div class="card-grid">
+            <article class="info-card">
+              <h2 data-i18n="sections.social.indicators.title">Indicateurs</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.social.indicators.items.engagement">Indice d’engagement, absentéisme, eNPS.</li>
+                <li data-i18n="sections.social.indicators.items.diversity">Diversité, égalité professionnelle, inclusion.</li>
+                <li data-i18n="sections.social.indicators.items.csr">Solidarité, achats responsables, mécénat.</li>
+              </ul>
+            </article>
+            <article class="info-card">
+              <h2 data-i18n="sections.social.programs.title">Programmes</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.social.programs.items.surveys">Campagnes d’écoute &amp; questionnaires anonymisés.</li>
+                <li data-i18n="sections.social.programs.items.training">Plans de formation, certifications, montée en compétences.</li>
+                <li data-i18n="sections.social.programs.items.community">Suivi des initiatives locales et des partenaires associatifs.</li>
+              </ul>
+            </article>
+          </div>
+          <p class="view__note" data-i18n="sections.social.note">
+            Des tableaux de bord thématiques facilitent la communication interne et externe.
+          </p>
+        </section>
+
+        <section class="view" id="governance">
+          <header class="view__header">
+            <h1 class="view__title" data-role="section-title" data-i18n="sections.governance.title">Gouvernance</h1>
+            <p class="view__intro" data-i18n="sections.governance.intro">
+              Structurer les responsabilités, les risques et la conformité ESG.
+            </p>
+          </header>
+          <div class="card-grid">
+            <article class="info-card">
+              <h2 data-i18n="sections.governance.pillars.title">Piliers</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.governance.pillars.items.compliance">Cartographie conformité (éthique, anti-corruption, RGPD).</li>
+                <li data-i18n="sections.governance.pillars.items.risk">Registre des risques ESG avec plans de mitigation.</li>
+                <li data-i18n="sections.governance.pillars.items.ethics">Suivi des codes de conduite, lanceurs d’alerte, audits.</li>
+              </ul>
+            </article>
+            <article class="info-card">
+              <h2 data-i18n="sections.governance.data.title">Données &amp; process</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.governance.data.items.references">Référentiels associés : ISO 26000, LUCIE, Ecovadis.</li>
+                <li data-i18n="sections.governance.data.items.workflow">Workflow de validation croisé avec les comités.</li>
+                <li data-i18n="sections.governance.data.items.export">Exports automatiques pour le conseil d’administration.</li>
+              </ul>
+            </article>
+          </div>
+          <p class="view__note" data-i18n="sections.governance.note">
+            La gouvernance centralise aussi les politiques ESG et la documentation réglementaire.
+          </p>
+        </section>
+
+        <section class="view" id="annual-report">
+          <header class="view__header">
+            <h1 class="view__title" data-role="section-title" data-i18n="sections.annual.title">Rapport annuel RSE</h1>
+            <p class="view__intro" data-i18n="sections.annual.intro">
+              Génération automatique de rapports extra-financiers personnalisés.
+            </p>
+          </header>
+          <div class="card-grid">
+            <article class="info-card">
+              <h2 data-i18n="sections.annual.steps.title">Pour générer un rapport</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.annual.steps.items.framework">Choisir le référentiel (GRI, CSRD, ODD, etc.).</li>
+                <li data-i18n="sections.annual.steps.items.period">Sélectionner la période (mois/année à mois/année).</li>
+                <li data-i18n="sections.annual.steps.items.validation">Valider les sections et commentaires narratifs.</li>
+              </ul>
+            </article>
+            <article class="info-card">
+              <h2 data-i18n="sections.annual.deliverables.title">Livrables</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.annual.deliverables.items.pdf">Exports adaptatifs PDF et Word prêts à diffusion.</li>
+                <li data-i18n="sections.annual.deliverables.items.templates">Templates conformes aux référentiels choisis.</li>
+                <li data-i18n="sections.annual.deliverables.items.automation">Automatisation de la pré-remplissage avec données validées.</li>
+              </ul>
+            </article>
+          </div>
+          <p class="view__note" data-i18n="sections.annual.note">
+            Un module de langage propose plusieurs exemples de rapports pour inspirer la rédaction.
+          </p>
+        </section>
+
+        <section class="view" id="performance-report">
+          <header class="view__header">
+            <h1 class="view__title" data-role="section-title" data-i18n="sections.performance.title">Rapport de performance</h1>
+            <p class="view__intro" data-i18n="sections.performance.intro">
+              Tableaux comparatifs et analyses rapides pour suivre les résultats.
+            </p>
+          </header>
+          <div class="card-grid">
+            <article class="info-card">
+              <h2 data-i18n="sections.performance.steps.title">Configuration</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.performance.steps.items.filters">Choisir les filtres et indicateurs à comparer.</li>
+                <li data-i18n="sections.performance.steps.items.period">Définir la période de couverture (mois/année).</li>
+                <li data-i18n="sections.performance.steps.items.share">Partager le rapport ou programmer l’envoi automatique.</li>
+              </ul>
+            </article>
+            <article class="info-card">
+              <h2 data-i18n="sections.performance.outputs.title">Sorties</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.performance.outputs.items.comparative">Tableaux comparatifs N vs N-1 ou objectif.</li>
+                <li data-i18n="sections.performance.outputs.items.scorecards">Scorecards par BU avec statut couleur.</li>
+                <li data-i18n="sections.performance.outputs.items.notifications">Notifications lors d’écarts majeurs sur un indicateur.</li>
+              </ul>
+            </article>
+          </div>
+          <p class="view__note" data-i18n="sections.performance.note">
+            Export disponible en PDF, Excel et connecteur Power BI.
+          </p>
+        </section>
+
+        <section class="view" id="parameters">
+          <header class="view__header">
+            <h1 class="view__title" data-role="section-title" data-i18n="sections.parameters.title">Administration</h1>
+            <p class="view__intro" data-i18n="sections.parameters.intro">
+              Gestion des paramètres globaux et des accès utilisateurs.
+            </p>
+          </header>
+          <div class="card-grid">
+            <article class="info-card">
+              <h2 data-i18n="sections.parameters.org.title">Organisation</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.parameters.org.items.structure">Structure : entités, BU, sites, équipes.</li>
+                <li data-i18n="sections.parameters.org.items.entitlements">Droits : rôles, scopes, délégations temporaires.</li>
+                <li data-i18n="sections.parameters.org.items.localization">Localisation : devise, fuseaux, langues.</li>
+              </ul>
+            </article>
+            <article class="info-card">
+              <h2 data-i18n="sections.parameters.targets.title">Objectifs &amp; alertes</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.parameters.targets.items.strategy">Alignement stratégique avec les objectifs groupe.</li>
+                <li data-i18n="sections.parameters.targets.items.kpi">Objectifs par indicateur et trajectoires associées.</li>
+                <li data-i18n="sections.parameters.targets.items.alerts">Seuils d’alerte et canaux de notification.</li>
+              </ul>
+            </article>
+          </div>
+          <div class="callout" role="note" data-i18n="sections.parameters.callout">
+            Les administrateurs peuvent simuler l’activation de nouveaux modules avant déploiement.
+          </div>
+        </section>
+      </main>
+    </div>
+
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,613 @@
+const translations = {
+  fr: {
+    'brand.title': 'Ecopilot',
+    'brand.subtitle': 'Pilotage ESG',
+    'welcome.title': 'Bienvenue',
+    'welcome.user': 'Utilisateur',
+    'actions.sidebar.collapse': 'Replier le menu',
+    'actions.sidebar.expand': 'Déployer le menu',
+    'actions.theme.dark': 'Mode sombre',
+    'actions.theme.light': 'Mode clair',
+    'buttons.logout': 'Déconnexion',
+    'breadcrumbs.home': 'Accueil',
+    'user.role': 'Admin',
+    'user.status': 'Connecté',
+    'nav.sections.overview': 'Vue générale',
+    'nav.sections.database': 'Base de données',
+    'nav.sections.modules': 'Modules d’analyse',
+    'nav.sections.reporting': 'Reporting',
+    'nav.sections.parameters': 'Paramètres',
+    'nav.overview.label': 'Main KPIs',
+    'nav.dataEntry.label': 'Saisie de données',
+    'nav.filters.label': 'Filtres & vues',
+    'nav.activity.label': 'Activité & suivi',
+    'nav.carbon.label': 'Empreinte carbone',
+    'nav.energy.label': 'Gestion de l’énergie',
+    'nav.social.label': 'Social & sociétal',
+    'nav.governance.label': 'Gouvernance',
+    'nav.annual.label': 'Rapport annuel RSE',
+    'nav.performance.label': 'Rapport de performance',
+    'nav.parameters.label': 'Administration',
+    'nav.popover.hint': 'Survoler pour explorer le module complet.',
+    'nav.dataEntry.submodules.title': 'Sous-modules',
+    'nav.dataEntry.submodules.items.business': 'BU',
+    'nav.dataEntry.submodules.items.activity': 'Activité',
+    'nav.dataEntry.submodules.items.filters': 'Filtres',
+    'nav.dataEntry.submodules.items.sites': 'Sites',
+    'nav.filters.submodules.title': 'Sous-modules',
+    'nav.filters.submodules.items.global': 'Vue globale',
+    'nav.filters.submodules.items.business': 'Vue BU',
+    'nav.filters.submodules.items.site': 'Vue site',
+    'nav.filters.submodules.items.saved': 'Filtres enregistrés',
+    'nav.activity.submodules.title': 'Sous-modules',
+    'nav.activity.submodules.items.workflow': 'Workflows',
+    'nav.activity.submodules.items.notifications': 'Notifications',
+    'nav.activity.submodules.items.history': 'Historique',
+    'nav.carbon.submodules.title': 'Focus',
+    'nav.carbon.submodules.items.scope1': 'Scope 1',
+    'nav.carbon.submodules.items.scope2': 'Scope 2',
+    'nav.carbon.submodules.items.scope3': 'Scope 3',
+    'nav.carbon.submodules.items.actionPlans': 'Plans d’action',
+    'nav.energy.submodules.title': 'Focus',
+    'nav.energy.submodules.items.consumption': 'Consommations',
+    'nav.energy.submodules.items.optimisation': 'Optimisation',
+    'nav.energy.submodules.items.alerts': 'Alertes',
+    'nav.social.submodules.title': 'Focus',
+    'nav.social.submodules.items.engagement': 'Engagement',
+    'nav.social.submodules.items.diversity': 'Diversité',
+    'nav.social.submodules.items.qvt': 'Qualité de vie au travail',
+    'nav.governance.submodules.title': 'Focus',
+    'nav.governance.submodules.items.comite': 'Comités',
+    'nav.governance.submodules.items.risk': 'Risques',
+    'nav.governance.submodules.items.compliance': 'Conformité',
+    'nav.annual.submodules.title': 'Livrables',
+    'nav.annual.submodules.items.structure': 'Structure du rapport',
+    'nav.annual.submodules.items.sources': 'Sources de données',
+    'nav.annual.submodules.items.validation': 'Validation',
+    'nav.performance.submodules.title': 'Livrables',
+    'nav.performance.submodules.items.comparative': 'Tableaux comparatifs',
+    'nav.performance.submodules.items.exports': 'Exports',
+    'nav.performance.submodules.items.sharing': 'Partage',
+    'nav.parameters.submodules.title': 'Gestion',
+    'nav.parameters.submodules.items.users': 'Utilisateurs',
+    'nav.parameters.submodules.items.security': 'Sécurité',
+    'nav.parameters.submodules.items.settings': 'Paramètres globaux',
+    'sections.dashboard.title': 'Main KPIs, graphiques & indicateurs',
+    'sections.dashboard.intro': 'Une page d’accueil pensée pour donner immédiatement la tendance ESG, accéder aux modules clés et guider l’utilisateur vers les actions prioritaires.',
+    'sections.dashboard.parameters.title': 'Paramètres',
+    'sections.dashboard.parameters.note': 'Administration globale par l’organisation cliente.',
+    'sections.dashboard.parameters.items.profile': 'Profil',
+    'sections.dashboard.parameters.items.organization': 'Organisation',
+    'sections.dashboard.parameters.items.subscription': 'Abonnement',
+    'sections.dashboard.parameters.items.notifications': 'Notifications',
+    'sections.dashboard.parameters.items.objectives': 'Objectifs',
+    'sections.dashboard.modules.title': 'Modules',
+    'sections.dashboard.modules.note': 'Accès direct aux flux métiers.',
+    'sections.dashboard.modules.items.energy': 'Gestion de l’énergie',
+    'sections.dashboard.modules.items.carbon': 'Empreinte carbone',
+    'sections.dashboard.modules.items.social': 'Sociale & sociétale',
+    'sections.dashboard.modules.items.governance': 'Gouvernance & risques',
+    'sections.dashboard.alignment.title': 'Alignement RSE',
+    'sections.dashboard.alignment.note': 'Suivi du niveau de couverture des référentiels.',
+    'sections.dashboard.alignment.items.gri': 'GRI',
+    'sections.dashboard.alignment.items.odds': 'ODD',
+    'sections.dashboard.alignment.items.csrd': 'CSRD',
+    'sections.dashboard.alignment.items.iso': 'ISO 26000',
+    'sections.dashboard.main.title': 'Main KPIs',
+    'sections.dashboard.main.note': 'Sélection personnalisée par rôle.',
+    'sections.dashboard.main.items.primary': 'Indicateurs prioritaires',
+    'sections.dashboard.main.items.secondary': 'Graphiques dynamiques',
+    'sections.dashboard.main.items.custom': 'Widgets personnalisés',
+    'sections.dashboard.main.placeholder': 'Ajouter un module de visualisation',
+    'sections.dashboard.note': 'NB : les sous-modules s’affichent automatiquement selon les droits et modules activés.',
+    'sections.dataEntry.title': 'Saisie de données',
+    'sections.dataEntry.intro': 'Workflow collaboratif depuis la collecte terrain jusqu’à la consolidation groupe.',
+    'sections.dataEntry.steps.title': 'Étapes clés',
+    'sections.dataEntry.steps.items.collect': 'Collecte : formulaires normalisés, imports Excel assistés.',
+    'sections.dataEntry.steps.items.validate': 'Validation : contrôles automatiques et revue du Super User.',
+    'sections.dataEntry.steps.items.approve': 'Approbation : verrouillage, horodatage et envoi vers les indicateurs.',
+    'sections.dataEntry.controls.title': 'Contrôles & traçabilité',
+    'sections.dataEntry.controls.items.traceability': 'Historique complet des contributions par rôle.',
+    'sections.dataEntry.controls.items.version': 'Versionning des campagnes mensuelles / trimestrielles.',
+    'sections.dataEntry.controls.items.audit': 'Journal d’audit exportable pour les commissaires.',
+    'sections.dataEntry.integrations.title': 'Intégrations',
+    'sections.dataEntry.integrations.items.internal': 'Connexion aux ERP internes (SAP, Oracle, Sage…).',
+    'sections.dataEntry.integrations.items.external': 'Imports ponctuels depuis bases externes ou prestataires.',
+    'sections.dataEntry.integrations.items.apis': 'API sécurisée pour industrialiser les synchronisations.',
+    'sections.dataEntry.callout': 'Un modèle de langage embarqué propose des recommandations qualité et suggère des valeurs lorsqu’une donnée manque.',
+    'sections.filters.title': 'Filtres & vues',
+    'sections.filters.intro': 'Affinez l’analyse en croisant les périmètres métiers, temporels et géographiques.',
+    'sections.filters.matrix.title': 'Axes de filtrage',
+    'sections.filters.matrix.items.period': 'Période : mois, trimestre, année, multi-années.',
+    'sections.filters.matrix.items.scope': 'Périmètre : groupe, BU, site, fournisseur.',
+    'sections.filters.matrix.items.activity': 'Activité : processus, projets, portefeuille d’initiatives.',
+    'sections.filters.matrix.items.impact': 'Impact : environnemental, social, gouvernance.',
+    'sections.filters.usage.title': 'Cas d’usage',
+    'sections.filters.usage.items.snapshots': 'Créer des vues instantanées pour les comités.',
+    'sections.filters.usage.items.comparisons': 'Comparer N vs N-1 ou objectif vs réalisé.',
+    'sections.filters.usage.items.alerts': 'Sauvegarder un filtre et recevoir une alerte en cas d’écart.',
+    'sections.filters.note': 'Les filtres peuvent être sauvegardés, partagés ou utilisés pour générer automatiquement un rapport.',
+    'sections.activity.title': 'Activité & suivi',
+    'sections.activity.intro': 'Pilotage quotidien des actions et notifications issues des modules.',
+    'sections.activity.timeline.title': 'Journal d’activité',
+    'sections.activity.timeline.items.tasks': 'Tâches assignées par module et niveau de priorité.',
+    'sections.activity.timeline.items.changelog': 'Historique des modifications avec commentaires.',
+    'sections.activity.timeline.items.comments': 'Fil de discussion entre contributeurs et managers.',
+    'sections.activity.security.title': 'Gouvernance',
+    'sections.activity.security.items.roles': 'Droits différenciés : Admin, Super User, Agent de saisie.',
+    'sections.activity.security.items.approvals': 'Workflow d’approbation configurable par module.',
+    'sections.activity.security.items.archives': 'Archivage automatique des campagnes terminées.',
+    'sections.activity.callout': 'Un tableau de bord de notifications consolide les alertes critiques pour garder la maîtrise des délais.',
+    'sections.carbon.title': 'Empreinte carbone',
+    'sections.carbon.intro': 'Piloter les émissions sur les scopes 1, 2 et 3 avec une vision budgétaire.',
+    'sections.carbon.focus.title': 'Périmètre & facteurs',
+    'sections.carbon.focus.items.scopes': 'Calcul automatisé des scopes 1, 2 et 3 avec facteurs certifiés.',
+    'sections.carbon.focus.items.factors': 'Mise à jour des facteurs ADEME, DEFRA, IEA et facteurs maison.',
+    'sections.carbon.focus.items.trajectory': 'Construction de trajectoires SBTi et budgets carbone par BU.',
+    'sections.carbon.outputs.title': 'Restitution',
+    'sections.carbon.outputs.items.reporting': 'Exports conformes CSRD, CDP, BEGES, label bas carbone.',
+    'sections.carbon.outputs.items.alerts': 'Alertes sur dérives d’intensité ou ruptures de données.',
+    'sections.carbon.outputs.items.actions': 'Plan d’actions bas carbone avec suivi ROI & co-bénéfices.',
+    'sections.carbon.note': 'Intégration possible avec des capteurs IoT et plateformes fournisseurs pour enrichir le scope 3.',
+    'sections.energy.title': 'Gestion de l’énergie',
+    'sections.energy.intro': 'Suivre les consommations, mesurer l’intensité énergétique et piloter la sobriété.',
+    'sections.energy.monitoring.title': 'Suivi',
+    'sections.energy.monitoring.items.consumption': 'Consolidation multi-énergies et visualisation des pics.',
+    'sections.energy.monitoring.items.intensity': 'Indicateurs d’intensité par m², unité produite ou site.',
+    'sections.energy.monitoring.items.investments': 'Suivi des investissements efficacité et de leur ROI.',
+    'sections.energy.optimisation.title': 'Optimisation',
+    'sections.energy.optimisation.items.plan': 'Plan de sobriété avec jalons et responsables.',
+    'sections.energy.optimisation.items.projects': 'Portefeuille de projets (ISO 50001, CEE, relamping…).',
+    'sections.energy.optimisation.items.budget': 'Pilotage budgétaire : CAPEX, OPEX, certificats d’économie.',
+    'sections.energy.note': 'Des connecteurs télérelève permettent d’automatiser la collecte en quasi temps réel.',
+    'sections.social.title': 'Social & sociétal',
+    'sections.social.intro': 'Mesurer l’engagement des collaborateurs et l’impact des actions sociétales.',
+    'sections.social.indicators.title': 'Indicateurs',
+    'sections.social.indicators.items.engagement': 'Indice d’engagement, absentéisme, eNPS.',
+    'sections.social.indicators.items.diversity': 'Diversité, égalité professionnelle, inclusion.',
+    'sections.social.indicators.items.csr': 'Solidarité, achats responsables, mécénat.',
+    'sections.social.programs.title': 'Programmes',
+    'sections.social.programs.items.surveys': 'Campagnes d’écoute & questionnaires anonymisés.',
+    'sections.social.programs.items.training': 'Plans de formation, certifications, montée en compétences.',
+    'sections.social.programs.items.community': 'Suivi des initiatives locales et des partenaires associatifs.',
+    'sections.social.note': 'Des tableaux de bord thématiques facilitent la communication interne et externe.',
+    'sections.governance.title': 'Gouvernance',
+    'sections.governance.intro': 'Structurer les responsabilités, les risques et la conformité ESG.',
+    'sections.governance.pillars.title': 'Piliers',
+    'sections.governance.pillars.items.compliance': 'Cartographie conformité (éthique, anti-corruption, RGPD).',
+    'sections.governance.pillars.items.risk': 'Registre des risques ESG avec plans de mitigation.',
+    'sections.governance.pillars.items.ethics': 'Suivi des codes de conduite, lanceurs d’alerte, audits.',
+    'sections.governance.data.title': 'Données & process',
+    'sections.governance.data.items.references': 'Référentiels associés : ISO 26000, LUCIE, Ecovadis.',
+    'sections.governance.data.items.workflow': 'Workflow de validation croisé avec les comités.',
+    'sections.governance.data.items.export': 'Exports automatiques pour le conseil d’administration.',
+    'sections.governance.note': 'La gouvernance centralise aussi les politiques ESG et la documentation réglementaire.',
+    'sections.annual.title': 'Rapport annuel RSE',
+    'sections.annual.intro': 'Génération automatique de rapports extra-financiers personnalisés.',
+    'sections.annual.steps.title': 'Pour générer un rapport',
+    'sections.annual.steps.items.framework': 'Choisir le référentiel (GRI, CSRD, ODD, etc.).',
+    'sections.annual.steps.items.period': 'Sélectionner la période (mois/année à mois/année).',
+    'sections.annual.steps.items.validation': 'Valider les sections et commentaires narratifs.',
+    'sections.annual.deliverables.title': 'Livrables',
+    'sections.annual.deliverables.items.pdf': 'Exports adaptatifs PDF et Word prêts à diffusion.',
+    'sections.annual.deliverables.items.templates': 'Templates conformes aux référentiels choisis.',
+    'sections.annual.deliverables.items.automation': 'Automatisation de la pré-remplissage avec données validées.',
+    'sections.annual.note': 'Un module de langage propose plusieurs exemples de rapports pour inspirer la rédaction.',
+    'sections.performance.title': 'Rapport de performance',
+    'sections.performance.intro': 'Tableaux comparatifs et analyses rapides pour suivre les résultats.',
+    'sections.performance.steps.title': 'Configuration',
+    'sections.performance.steps.items.filters': 'Choisir les filtres et indicateurs à comparer.',
+    'sections.performance.steps.items.period': 'Définir la période de couverture (mois/année).',
+    'sections.performance.steps.items.share': 'Partager le rapport ou programmer l’envoi automatique.',
+    'sections.performance.outputs.title': 'Sorties',
+    'sections.performance.outputs.items.comparative': 'Tableaux comparatifs N vs N-1 ou objectif.',
+    'sections.performance.outputs.items.scorecards': 'Scorecards par BU avec statut couleur.',
+    'sections.performance.outputs.items.notifications': 'Notifications lors d’écarts majeurs sur un indicateur.',
+    'sections.performance.note': 'Export disponible en PDF, Excel et connecteur Power BI.',
+    'sections.parameters.title': 'Administration',
+    'sections.parameters.intro': 'Gestion des paramètres globaux et des accès utilisateurs.',
+    'sections.parameters.org.title': 'Organisation',
+    'sections.parameters.org.items.structure': 'Structure : entités, BU, sites, équipes.',
+    'sections.parameters.org.items.entitlements': 'Droits : rôles, scopes, délégations temporaires.',
+    'sections.parameters.org.items.localization': 'Localisation : devise, fuseaux, langues.',
+    'sections.parameters.targets.title': 'Objectifs & alertes',
+    'sections.parameters.targets.items.strategy': 'Alignement stratégique avec les objectifs groupe.',
+    'sections.parameters.targets.items.kpi': 'Objectifs par indicateur et trajectoires associées.',
+    'sections.parameters.targets.items.alerts': 'Seuils d’alerte et canaux de notification.',
+    'sections.parameters.callout': 'Les administrateurs peuvent simuler l’activation de nouveaux modules avant déploiement.'
+  },
+  en: {
+    'brand.title': 'Ecopilot',
+    'brand.subtitle': 'ESG cockpit',
+    'welcome.title': 'Welcome',
+    'welcome.user': 'User',
+    'actions.sidebar.collapse': 'Collapse menu',
+    'actions.sidebar.expand': 'Expand menu',
+    'actions.theme.dark': 'Dark mode',
+    'actions.theme.light': 'Light mode',
+    'buttons.logout': 'Sign out',
+    'breadcrumbs.home': 'Home',
+    'user.role': 'Admin',
+    'user.status': 'Online',
+    'nav.sections.overview': 'Overview',
+    'nav.sections.database': 'Data hub',
+    'nav.sections.modules': 'Analysis modules',
+    'nav.sections.reporting': 'Reporting',
+    'nav.sections.parameters': 'Settings',
+    'nav.overview.label': 'Main KPIs',
+    'nav.dataEntry.label': 'Data entry',
+    'nav.filters.label': 'Filters & views',
+    'nav.activity.label': 'Activity log',
+    'nav.carbon.label': 'Carbon footprint',
+    'nav.energy.label': 'Energy management',
+    'nav.social.label': 'Social & societal',
+    'nav.governance.label': 'Governance',
+    'nav.annual.label': 'Annual ESG report',
+    'nav.performance.label': 'Performance report',
+    'nav.parameters.label': 'Administration',
+    'nav.popover.hint': 'Hover to explore the full module.',
+    'nav.dataEntry.submodules.title': 'Sub-modules',
+    'nav.dataEntry.submodules.items.business': 'Business units',
+    'nav.dataEntry.submodules.items.activity': 'Activity',
+    'nav.dataEntry.submodules.items.filters': 'Filters',
+    'nav.dataEntry.submodules.items.sites': 'Sites',
+    'nav.filters.submodules.title': 'Sub-modules',
+    'nav.filters.submodules.items.global': 'Global view',
+    'nav.filters.submodules.items.business': 'BU view',
+    'nav.filters.submodules.items.site': 'Site view',
+    'nav.filters.submodules.items.saved': 'Saved filters',
+    'nav.activity.submodules.title': 'Sub-modules',
+    'nav.activity.submodules.items.workflow': 'Workflows',
+    'nav.activity.submodules.items.notifications': 'Notifications',
+    'nav.activity.submodules.items.history': 'History',
+    'nav.carbon.submodules.title': 'Highlights',
+    'nav.carbon.submodules.items.scope1': 'Scope 1',
+    'nav.carbon.submodules.items.scope2': 'Scope 2',
+    'nav.carbon.submodules.items.scope3': 'Scope 3',
+    'nav.carbon.submodules.items.actionPlans': 'Action plans',
+    'nav.energy.submodules.title': 'Highlights',
+    'nav.energy.submodules.items.consumption': 'Consumption',
+    'nav.energy.submodules.items.optimisation': 'Optimisation',
+    'nav.energy.submodules.items.alerts': 'Alerts',
+    'nav.social.submodules.title': 'Highlights',
+    'nav.social.submodules.items.engagement': 'Engagement',
+    'nav.social.submodules.items.diversity': 'Diversity',
+    'nav.social.submodules.items.qvt': 'Workplace wellbeing',
+    'nav.governance.submodules.title': 'Highlights',
+    'nav.governance.submodules.items.comite': 'Committees',
+    'nav.governance.submodules.items.risk': 'Risks',
+    'nav.governance.submodules.items.compliance': 'Compliance',
+    'nav.annual.submodules.title': 'Deliverables',
+    'nav.annual.submodules.items.structure': 'Report structure',
+    'nav.annual.submodules.items.sources': 'Data sources',
+    'nav.annual.submodules.items.validation': 'Validation',
+    'nav.performance.submodules.title': 'Deliverables',
+    'nav.performance.submodules.items.comparative': 'Comparative tables',
+    'nav.performance.submodules.items.exports': 'Exports',
+    'nav.performance.submodules.items.sharing': 'Sharing',
+    'nav.parameters.submodules.title': 'Administration',
+    'nav.parameters.submodules.items.users': 'Users',
+    'nav.parameters.submodules.items.security': 'Security',
+    'nav.parameters.submodules.items.settings': 'Global settings',
+    'sections.dashboard.title': 'Main KPIs, charts & indicators',
+    'sections.dashboard.intro': 'A homepage designed to display the ESG pulse, provide shortcuts to core modules, and highlight priority actions.',
+    'sections.dashboard.parameters.title': 'Parameters',
+    'sections.dashboard.parameters.note': 'Admin scope managed at organisation level.',
+    'sections.dashboard.parameters.items.profile': 'Profile',
+    'sections.dashboard.parameters.items.organization': 'Organisation',
+    'sections.dashboard.parameters.items.subscription': 'Subscription',
+    'sections.dashboard.parameters.items.notifications': 'Notifications',
+    'sections.dashboard.parameters.items.objectives': 'Objectives',
+    'sections.dashboard.modules.title': 'Modules',
+    'sections.dashboard.modules.note': 'Quick access to operational flows.',
+    'sections.dashboard.modules.items.energy': 'Energy management',
+    'sections.dashboard.modules.items.carbon': 'Carbon footprint',
+    'sections.dashboard.modules.items.social': 'Social & societal',
+    'sections.dashboard.modules.items.governance': 'Governance & risks',
+    'sections.dashboard.alignment.title': 'ESG alignment',
+    'sections.dashboard.alignment.note': 'Track coverage vs leading frameworks.',
+    'sections.dashboard.alignment.items.gri': 'GRI',
+    'sections.dashboard.alignment.items.odds': 'SDGs',
+    'sections.dashboard.alignment.items.csrd': 'CSRD',
+    'sections.dashboard.alignment.items.iso': 'ISO 26000',
+    'sections.dashboard.main.title': 'Main KPIs',
+    'sections.dashboard.main.note': 'Personalised selection per role.',
+    'sections.dashboard.main.items.primary': 'Priority indicators',
+    'sections.dashboard.main.items.secondary': 'Dynamic charts',
+    'sections.dashboard.main.items.custom': 'Custom widgets',
+    'sections.dashboard.main.placeholder': 'Add a visual module',
+    'sections.dashboard.note': 'NB: sub-modules appear automatically based on entitlements and activated features.',
+    'sections.dataEntry.title': 'Data entry',
+    'sections.dataEntry.intro': 'Collaborative workflow from field collection to group consolidation.',
+    'sections.dataEntry.steps.title': 'Key steps',
+    'sections.dataEntry.steps.items.collect': 'Collection: guided forms and assisted spreadsheet uploads.',
+    'sections.dataEntry.steps.items.validate': 'Validation: automated checks and Super User review.',
+    'sections.dataEntry.steps.items.approve': 'Approval: lock, timestamp and push to indicators.',
+    'sections.dataEntry.controls.title': 'Controls & traceability',
+    'sections.dataEntry.controls.items.traceability': 'Complete history of contributions by role.',
+    'sections.dataEntry.controls.items.version': 'Versioning for monthly / quarterly campaigns.',
+    'sections.dataEntry.controls.items.audit': 'Exportable audit trail for auditors.',
+    'sections.dataEntry.integrations.title': 'Integrations',
+    'sections.dataEntry.integrations.items.internal': 'Connections to internal ERPs (SAP, Oracle, Sage…).',
+    'sections.dataEntry.integrations.items.external': 'One-off imports from external databases or providers.',
+    'sections.dataEntry.integrations.items.apis': 'Secure API to industrialise synchronisations.',
+    'sections.dataEntry.callout': 'An embedded language model suggests quality improvements and proposes values when a data point is missing.',
+    'sections.filters.title': 'Filters & views',
+    'sections.filters.intro': 'Refine the analysis by crossing business, time and geographic scopes.',
+    'sections.filters.matrix.title': 'Filtering axes',
+    'sections.filters.matrix.items.period': 'Period: month, quarter, year, multi-year.',
+    'sections.filters.matrix.items.scope': 'Scope: group, BU, site, supplier.',
+    'sections.filters.matrix.items.activity': 'Activity: process, projects, initiative portfolio.',
+    'sections.filters.matrix.items.impact': 'Impact: environmental, social, governance.',
+    'sections.filters.usage.title': 'Use cases',
+    'sections.filters.usage.items.snapshots': 'Create instant snapshots for steering committees.',
+    'sections.filters.usage.items.comparisons': 'Compare current vs previous year or target vs actual.',
+    'sections.filters.usage.items.alerts': 'Save a filter and trigger alerts when deviations occur.',
+    'sections.filters.note': 'Filters can be saved, shared, or reused to automatically generate a report.',
+    'sections.activity.title': 'Activity log',
+    'sections.activity.intro': 'Day-to-day follow-up of tasks and notifications from the modules.',
+    'sections.activity.timeline.title': 'Activity journal',
+    'sections.activity.timeline.items.tasks': 'Assigned tasks by module with priority level.',
+    'sections.activity.timeline.items.changelog': 'Change history with comments.',
+    'sections.activity.timeline.items.comments': 'Discussion thread between contributors and managers.',
+    'sections.activity.security.title': 'Governance',
+    'sections.activity.security.items.roles': 'Role-based access: Admin, Super User, Data Entry agent.',
+    'sections.activity.security.items.approvals': 'Configurable approval workflow per module.',
+    'sections.activity.security.items.archives': 'Automatic archiving of completed campaigns.',
+    'sections.activity.callout': 'A consolidated notification board keeps critical alerts under control.',
+    'sections.carbon.title': 'Carbon footprint',
+    'sections.carbon.intro': 'Steer emissions across scopes 1, 2 and 3 with a budget view.',
+    'sections.carbon.focus.title': 'Scope & factors',
+    'sections.carbon.focus.items.scopes': 'Automated calculation for scopes 1, 2 and 3 with certified factors.',
+    'sections.carbon.focus.items.factors': 'Updates with ADEME, DEFRA, IEA and custom factors.',
+    'sections.carbon.focus.items.trajectory': 'Build SBTi trajectories and carbon budgets per BU.',
+    'sections.carbon.outputs.title': 'Outputs',
+    'sections.carbon.outputs.items.reporting': 'CSRD, CDP, BEGES and low-carbon label ready exports.',
+    'sections.carbon.outputs.items.alerts': 'Alerts on intensity drifts or data gaps.',
+    'sections.carbon.outputs.items.actions': 'Low-carbon action plan with ROI & co-benefits tracking.',
+    'sections.carbon.note': 'IoT sensors and supplier platforms can be connected to enrich scope 3.',
+    'sections.energy.title': 'Energy management',
+    'sections.energy.intro': 'Monitor consumption, measure intensity and drive energy savings.',
+    'sections.energy.monitoring.title': 'Monitoring',
+    'sections.energy.monitoring.items.consumption': 'Multi-energy consolidation with peak visualisation.',
+    'sections.energy.monitoring.items.intensity': 'Intensity indicators per sqm, production unit or site.',
+    'sections.energy.monitoring.items.investments': 'Track efficiency investments and their ROI.',
+    'sections.energy.optimisation.title': 'Optimisation',
+    'sections.energy.optimisation.items.plan': 'Sobriety plan with milestones and owners.',
+    'sections.energy.optimisation.items.projects': 'Project portfolio (ISO 50001, energy certificates, relamping…).',
+    'sections.energy.optimisation.items.budget': 'Budget steering: CAPEX, OPEX, energy savings certificates.',
+    'sections.energy.note': 'Smart meter connectors enable near real-time collection.',
+    'sections.social.title': 'Social & societal',
+    'sections.social.intro': 'Measure employee engagement and the impact of societal initiatives.',
+    'sections.social.indicators.title': 'Indicators',
+    'sections.social.indicators.items.engagement': 'Engagement index, absenteeism, eNPS.',
+    'sections.social.indicators.items.diversity': 'Diversity, gender equality, inclusion.',
+    'sections.social.indicators.items.csr': 'Solidarity, responsible procurement, philanthropy.',
+    'sections.social.programs.title': 'Programs',
+    'sections.social.programs.items.surveys': 'Listening campaigns & anonymised surveys.',
+    'sections.social.programs.items.training': 'Training plans, certifications, upskilling.',
+    'sections.social.programs.items.community': 'Tracking of local initiatives and community partners.',
+    'sections.social.note': 'Thematic dashboards streamline internal and external communication.',
+    'sections.governance.title': 'Governance',
+    'sections.governance.intro': 'Structure responsibilities, risks and ESG compliance.',
+    'sections.governance.pillars.title': 'Pillars',
+    'sections.governance.pillars.items.compliance': 'Compliance map (ethics, anti-corruption, GDPR).',
+    'sections.governance.pillars.items.risk': 'ESG risk register with mitigation plans.',
+    'sections.governance.pillars.items.ethics': 'Monitoring of codes of conduct, whistleblowing, audits.',
+    'sections.governance.data.title': 'Data & processes',
+    'sections.governance.data.items.references': 'Linked frameworks: ISO 26000, LUCIE, Ecovadis.',
+    'sections.governance.data.items.workflow': 'Cross-validation workflow with committees.',
+    'sections.governance.data.items.export': 'Automatic exports for the board of directors.',
+    'sections.governance.note': 'Governance also centralises ESG policies and regulatory documentation.',
+    'sections.annual.title': 'Annual ESG report',
+    'sections.annual.intro': 'Automatic generation of bespoke sustainability reports.',
+    'sections.annual.steps.title': 'How to generate a report',
+    'sections.annual.steps.items.framework': 'Select the framework (GRI, CSRD, SDGs, etc.).',
+    'sections.annual.steps.items.period': 'Choose the reporting period (month/year to month/year).',
+    'sections.annual.steps.items.validation': 'Validate sections and narrative comments.',
+    'sections.annual.deliverables.title': 'Deliverables',
+    'sections.annual.deliverables.items.pdf': 'Adaptive PDF and Word outputs ready for distribution.',
+    'sections.annual.deliverables.items.templates': 'Templates aligned with the chosen frameworks.',
+    'sections.annual.deliverables.items.automation': 'Automation pre-fills with validated data.',
+    'sections.annual.note': 'An integrated language model proposes sample reports to support drafting.',
+    'sections.performance.title': 'Performance report',
+    'sections.performance.intro': 'Comparison tables and quick insights to track results.',
+    'sections.performance.steps.title': 'Configuration',
+    'sections.performance.steps.items.filters': 'Choose filters and indicators to compare.',
+    'sections.performance.steps.items.period': 'Define the coverage period (month/year).',
+    'sections.performance.steps.items.share': 'Share the report or schedule automatic delivery.',
+    'sections.performance.outputs.title': 'Outputs',
+    'sections.performance.outputs.items.comparative': 'Comparative tables current vs previous year or target.',
+    'sections.performance.outputs.items.scorecards': 'Scorecards by BU with status colours.',
+    'sections.performance.outputs.items.notifications': 'Notifications on major variances for any indicator.',
+    'sections.performance.note': 'Exports available in PDF, Excel and a Power BI connector.',
+    'sections.parameters.title': 'Administration',
+    'sections.parameters.intro': 'Manage global settings and user access.',
+    'sections.parameters.org.title': 'Organisation',
+    'sections.parameters.org.items.structure': 'Structure: entities, BUs, sites, teams.',
+    'sections.parameters.org.items.entitlements': 'Permissions: roles, scopes, temporary delegations.',
+    'sections.parameters.org.items.localization': 'Localisation: currency, time zones, languages.',
+    'sections.parameters.targets.title': 'Objectives & alerts',
+    'sections.parameters.targets.items.strategy': 'Strategic alignment with corporate goals.',
+    'sections.parameters.targets.items.kpi': 'Targets per KPI with associated trajectories.',
+    'sections.parameters.targets.items.alerts': 'Alert thresholds and notification channels.',
+    'sections.parameters.callout': 'Admins can simulate new module activation before rollout.'
+  }
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  const root = document.documentElement;
+  const app = document.querySelector('.app');
+  const main = document.getElementById('app-main');
+  const navButtons = Array.from(document.querySelectorAll('.nav-item'));
+  const sections = Array.from(document.querySelectorAll('.view'));
+  const crumbCurrent = document.querySelector('[data-role="current-section"]');
+  const languageButtons = Array.from(document.querySelectorAll('.language-switch__btn'));
+  const themeToggle = document.querySelector('[data-action="toggle-theme"]');
+  const sidebarToggle = document.querySelector('[data-action="collapse-sidebar"]');
+
+  const storageKeys = {
+    language: 'ecopilot:language',
+    theme: 'ecopilot:theme',
+    sidebar: 'ecopilot:sidebar'
+  };
+
+  const storage = {
+    get(key) {
+      try {
+        return window.localStorage.getItem(key);
+      } catch (error) {
+        return null;
+      }
+    },
+    set(key, value) {
+      try {
+        window.localStorage.setItem(key, value);
+      } catch (error) {
+        /* noop */
+      }
+    }
+  };
+
+  let activeLanguage = 'fr';
+
+  const getDictionary = (lang) => translations[lang] ?? translations.fr;
+
+  const translateKey = (key, lang = activeLanguage) => {
+    const dictionary = getDictionary(lang);
+    return dictionary[key] ?? key;
+  };
+
+  const updateBreadcrumb = () => {
+    if (!crumbCurrent) return;
+    const activeSection = sections.find((section) => section.classList.contains('is-active'));
+    if (!activeSection) return;
+    const title = activeSection.querySelector('[data-role="section-title"]');
+    if (!title) return;
+    crumbCurrent.textContent = title.textContent.trim();
+  };
+
+  const applyLanguage = (lang) => {
+    activeLanguage = translations[lang] ? lang : 'fr';
+    const dictionary = getDictionary(activeLanguage);
+    const translatable = document.querySelectorAll('[data-i18n]');
+    translatable.forEach((element) => {
+      const key = element.dataset.i18n;
+      if (!key) return;
+      const value = dictionary[key];
+      if (value === undefined) return;
+      element.innerHTML = value;
+    });
+    root.setAttribute('lang', activeLanguage);
+    languageButtons.forEach((button) => {
+      const isActive = button.dataset.lang === activeLanguage;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-pressed', String(isActive));
+    });
+    storage.set(storageKeys.language, activeLanguage);
+    updateBreadcrumb();
+  };
+
+  const setTheme = (theme) => {
+    const resolved = theme === 'dark' ? 'dark' : 'light';
+    document.body.setAttribute('data-theme', resolved);
+    if (themeToggle) {
+      themeToggle.setAttribute('aria-pressed', String(resolved === 'dark'));
+      const icon = themeToggle.querySelector('.theme-switch__icon');
+      if (icon) {
+        icon.textContent = resolved === 'dark' ? '☀️' : '🌙';
+      }
+      const label = themeToggle.querySelector('.theme-switch__label');
+      if (label) {
+        const key = resolved === 'dark' ? 'actions.theme.light' : 'actions.theme.dark';
+        label.dataset.i18n = key;
+        label.innerHTML = translateKey(key);
+      }
+    }
+    storage.set(storageKeys.theme, resolved);
+  };
+
+  const setSidebarCollapsed = (collapsed) => {
+    if (!app) return;
+    const isCollapsed = Boolean(collapsed);
+    app.classList.toggle('is-sidebar-collapsed', isCollapsed);
+    if (sidebarToggle) {
+      sidebarToggle.setAttribute('aria-expanded', String(!isCollapsed));
+      const icon = sidebarToggle.querySelector('.sidebar__collapse-icon');
+      if (icon) {
+        icon.textContent = isCollapsed ? '⮞' : '⮜';
+      }
+      const label = sidebarToggle.querySelector('.sidebar__collapse-label');
+      if (label) {
+        const key = isCollapsed ? 'actions.sidebar.expand' : 'actions.sidebar.collapse';
+        label.dataset.i18n = key;
+        label.innerHTML = translateKey(key);
+      }
+    }
+    storage.set(storageKeys.sidebar, isCollapsed ? '1' : '0');
+  };
+
+  const activateSection = (targetId) => {
+    const section = sections.find((item) => item.id === targetId);
+    if (!section) return;
+    sections.forEach((item) => {
+      item.classList.toggle('is-active', item === section);
+      if (item === section) {
+        item.scrollTop = 0;
+      }
+    });
+    navButtons.forEach((button) => {
+      const isActive = button.dataset.target === targetId;
+      button.classList.toggle('is-active', isActive);
+      if (isActive) {
+        button.setAttribute('aria-current', 'page');
+      } else {
+        button.removeAttribute('aria-current');
+      }
+    });
+    updateBreadcrumb();
+  };
+
+  navButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const targetId = button.dataset.target;
+      if (!targetId) return;
+      activateSection(targetId);
+    });
+  });
+
+  languageButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const lang = button.dataset.lang;
+      if (!lang) return;
+      applyLanguage(lang);
+    });
+  });
+
+  if (themeToggle) {
+    themeToggle.addEventListener('click', () => {
+      const current = document.body.getAttribute('data-theme');
+      const nextTheme = current === 'dark' ? 'light' : 'dark';
+      setTheme(nextTheme);
+    });
+  }
+
+  if (sidebarToggle) {
+    sidebarToggle.addEventListener('click', () => {
+      const collapsed = app?.classList.contains('is-sidebar-collapsed');
+      setSidebarCollapsed(!collapsed);
+    });
+  }
+
+  const savedSidebar = storage.get(storageKeys.sidebar) === '1';
+  setSidebarCollapsed(savedSidebar);
+
+  const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const savedTheme = storage.get(storageKeys.theme) || (prefersDark ? 'dark' : 'light');
+  setTheme(savedTheme);
+
+  const savedLanguage = storage.get(storageKeys.language) || 'fr';
+  applyLanguage(savedLanguage);
+
+  activateSection(sections.find((section) => section.classList.contains('is-active'))?.id || 'dashboard');
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,752 @@
+:root {
+  --font-family: 'Inter', sans-serif;
+  --color-bg: #f4f6fb;
+  --color-surface: #ffffff;
+  --color-surface-soft: #f0f4ff;
+  --color-surface-muted: #f7f9fc;
+  --color-text: #1f2937;
+  --color-text-muted: #4b5563;
+  --color-border: #d8dee9;
+  --color-accent: #2f6fed;
+  --color-accent-soft: rgba(47, 111, 237, 0.12);
+  --shadow-sm: 0 1px 3px rgba(15, 23, 42, 0.08);
+  --shadow-md: 0 18px 40px rgba(15, 23, 42, 0.12);
+  --radius-lg: 20px;
+  --radius-md: 14px;
+  --radius-sm: 10px;
+  --transition-base: 0.25s ease;
+}
+
+body[data-theme='dark'] {
+  --color-bg: #111827;
+  --color-surface: #1f2937;
+  --color-surface-soft: #16213a;
+  --color-surface-muted: #0f172a;
+  --color-text: #f9fafb;
+  --color-text-muted: #cbd5f5;
+  --color-border: rgba(148, 163, 184, 0.24);
+  --color-accent: #60a5fa;
+  --color-accent-soft: rgba(96, 165, 250, 0.18);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 20px 44px rgba(8, 13, 23, 0.5);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-family);
+  background: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+button {
+  font: inherit;
+  color: inherit;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+button:focus-visible,
+.language-switch__btn:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.app {
+  display: flex;
+  min-height: 100vh;
+  background: var(--color-bg);
+}
+
+.sidebar {
+  width: 320px;
+  background: var(--color-surface);
+  border-right: 1px solid var(--color-border);
+  padding: 28px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  transition: width var(--transition-base), padding var(--transition-base);
+}
+
+.sidebar__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.sidebar__brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.sidebar__logo {
+  font-size: 2rem;
+}
+
+.sidebar__brand-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sidebar__brand-title {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.95rem;
+}
+
+.sidebar__brand-subtitle {
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+  letter-spacing: 0.03em;
+}
+
+.sidebar__collapse {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-soft);
+  border: 1px solid transparent;
+  color: var(--color-text);
+  transition: background var(--transition-base), color var(--transition-base);
+}
+
+.sidebar__collapse:hover {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.sidebar__collapse-icon {
+  font-size: 1rem;
+  transition: transform var(--transition-base);
+}
+
+.sidebar__welcome {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-soft);
+  color: var(--color-text);
+}
+
+.sidebar__welcome-title {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+}
+
+.sidebar__welcome-user {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.sidebar__menu {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.sidebar__group {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sidebar__heading {
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.nav-item-wrapper {
+  position: relative;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
+  text-align: left;
+  transition: background var(--transition-base), box-shadow var(--transition-base), color var(--transition-base);
+}
+
+.nav-item__bullet {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  font-size: 0.7rem;
+  background: var(--color-surface-muted);
+  color: var(--color-text-muted);
+}
+
+.nav-item:hover {
+  background: var(--color-surface-soft);
+}
+
+.nav-item.is-active {
+  background: var(--color-accent);
+  color: #fff;
+  box-shadow: var(--shadow-sm);
+}
+
+.nav-item.is-active .nav-item__bullet {
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}
+
+.nav-item__popover {
+  position: absolute;
+  top: 50%;
+  left: calc(100% + 12px);
+  transform: translate3d(-8px, -50%, 0);
+  width: clamp(180px, 24vw, 240px);
+  padding: 12px 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  box-shadow: var(--shadow-md);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition-base), transform var(--transition-base);
+  z-index: 20;
+}
+
+.nav-item__popover::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 100%;
+  transform: translateY(-50%) rotate(45deg);
+  width: 12px;
+  height: 12px;
+  background: var(--color-surface);
+  border-left: 1px solid var(--color-border);
+  border-top: 1px solid var(--color-border);
+  transform-origin: center;
+}
+
+.nav-item-wrapper:hover .nav-item__popover,
+.nav-item-wrapper:focus-within .nav-item__popover {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate3d(0, -50%, 0);
+}
+
+.nav-item__popover-title {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.nav-item__popover-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 0;
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.nav-item__popover-note {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.sidebar__footer {
+  margin-top: auto;
+}
+
+.logout-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-soft);
+  color: var(--color-text);
+  transition: background var(--transition-base), color var(--transition-base);
+}
+
+.logout-button__icon {
+  font-size: 0.95rem;
+}
+
+.logout-button:hover {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: var(--color-bg);
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  padding: 24px 32px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.topbar__breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+.breadcrumb--current {
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.topbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.language-switch {
+  display: inline-flex;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--color-surface-muted);
+}
+
+.language-switch__btn {
+  padding: 6px 12px;
+  font-size: 0.85rem;
+  border-right: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  background: transparent;
+  transition: background var(--transition-base), color var(--transition-base);
+}
+
+.language-switch__btn:last-child {
+  border-right: none;
+}
+
+.language-switch__btn.is-active {
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.theme-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  padding: 8px 12px;
+  background: var(--color-surface-muted);
+  transition: background var(--transition-base), color var(--transition-base);
+}
+
+.theme-switch:hover {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.theme-switch__icon {
+  font-size: 1rem;
+}
+
+.user-badge {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  font-size: 0.8rem;
+  min-width: 110px;
+}
+
+.user-badge__role {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.user-badge__status {
+  font-size: 0.9rem;
+}
+
+.view {
+  display: none;
+  padding: 36px 48px 60px;
+  overflow-y: auto;
+}
+
+.view.is-active {
+  display: block;
+}
+
+.view__header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 28px;
+}
+
+.view__title {
+  margin: 0;
+  font-size: 1.85rem;
+  font-weight: 700;
+}
+
+.view__intro {
+  margin: 0;
+  color: var(--color-text-muted);
+  max-width: 760px;
+}
+
+.overview-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.overview-column {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.overview-column__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.overview-column__note {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+.overview-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.overview-list li {
+  position: relative;
+  padding-left: 18px;
+}
+
+.overview-list li::before {
+  content: '';
+  position: absolute;
+  top: 8px;
+  left: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  opacity: 0.65;
+}
+
+.overview-list--tags {
+  flex-wrap: wrap;
+  flex-direction: row;
+  gap: 10px;
+}
+
+.overview-list--tags li {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.overview-list--tags li::before {
+  display: none;
+}
+
+.plus-grid {
+  margin-top: auto;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.plus-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px dashed var(--color-border);
+  background: var(--color-surface-muted);
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.plus-card span:first-child {
+  font-size: 1.5rem;
+  color: var(--color-accent);
+}
+
+.view__note {
+  margin-top: 28px;
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+  background: var(--color-accent-soft);
+  border-left: 4px solid var(--color-accent);
+  padding: 14px 18px;
+  border-radius: var(--radius-md);
+}
+
+.card-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.info-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: var(--shadow-sm);
+  min-height: 220px;
+}
+
+.info-card h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.info-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  color: var(--color-text);
+}
+
+.info-list li {
+  position: relative;
+  padding-left: 18px;
+  font-size: 0.95rem;
+}
+
+.info-list li::before {
+  content: '';
+  position: absolute;
+  top: 8px;
+  left: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 3px;
+  background: var(--color-accent);
+  opacity: 0.65;
+}
+
+.callout {
+  margin-top: 28px;
+  padding: 18px 20px;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-soft);
+  color: var(--color-text);
+  border-left: 4px solid var(--color-accent);
+  box-shadow: var(--shadow-sm);
+}
+
+.app.is-sidebar-collapsed .sidebar {
+  width: 92px;
+  padding: 28px 12px;
+}
+
+.app.is-sidebar-collapsed .sidebar__brand-text,
+.app.is-sidebar-collapsed .sidebar__welcome,
+.app.is-sidebar-collapsed .sidebar__heading,
+.app.is-sidebar-collapsed .sidebar__collapse-label,
+.app.is-sidebar-collapsed .logout-button__label {
+  display: none;
+}
+
+.app.is-sidebar-collapsed .sidebar__collapse-icon {
+  transform: rotate(180deg);
+}
+
+.app.is-sidebar-collapsed .nav-item {
+  justify-content: center;
+  padding: 12px 10px;
+}
+
+.app.is-sidebar-collapsed .nav-item__label {
+  display: none;
+}
+
+.app.is-sidebar-collapsed .nav-item__bullet {
+  width: 30px;
+  height: 30px;
+  font-size: 0.8rem;
+}
+
+.app.is-sidebar-collapsed .logout-button {
+  justify-content: center;
+}
+
+@media (max-width: 1280px) {
+  .overview-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 960px) {
+  .app {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    width: 100%;
+    flex-direction: row;
+    align-items: flex-start;
+    padding: 20px;
+    gap: 20px;
+    overflow-x: auto;
+  }
+
+  .sidebar__top {
+    flex-direction: row;
+    flex: 1;
+  }
+
+  .sidebar__menu {
+    flex-direction: row;
+    gap: 24px;
+    flex: 2;
+  }
+
+  .sidebar__group {
+    min-width: 200px;
+  }
+
+  .sidebar__footer {
+    display: none;
+  }
+
+  .main {
+    min-height: calc(100vh - 220px);
+  }
+
+  .topbar {
+    position: static;
+  }
+
+  .app.is-sidebar-collapsed .sidebar {
+    width: 100%;
+    padding: 20px;
+  }
+}
+
+@media (max-width: 768px) {
+  .view {
+    padding: 28px 24px 48px;
+  }
+
+  .topbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .topbar__actions {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .overview-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .plus-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .sidebar {
+    padding: 16px;
+  }
+
+  .language-switch__btn {
+    padding: 6px 10px;
+  }
+
+  .theme-switch,
+  .logout-button {
+    padding: 8px 10px;
+  }
+
+  .view__title {
+    font-size: 1.6rem;
+  }
+}


### PR DESCRIPTION
## Summary
- wrap sidebar navigation buttons with hover flyouts that list key submodules for each module
- add French and English translation strings so the hover previews follow the language toggle
- style the flyouts to match the dashboard theme and remain usable in collapsed or dark sidebar modes

## Testing
- not run (static frontend)

------
https://chatgpt.com/codex/tasks/task_b_68d119e8bf28832a8fa494c693a09586