### PR TITLE
Restructure dashboard around requested module lineup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,485 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ecopilot – Prototype RSE</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body data-theme="light">
+    <div class="app" id="app-root">
+      <aside class="sidebar" id="app-sidebar">
+        <div class="sidebar__top">
+          <div class="sidebar__brand">
+            <span class="sidebar__logo" aria-hidden="true">🌱</span>
+            <div class="sidebar__brand-text">
+              <span class="sidebar__brand-title" data-i18n="brand.title">Ecopilot</span>
+              <span class="sidebar__brand-subtitle" data-i18n="brand.subtitle">Pilotage ESG</span>
+            </div>
+          </div>
+          <button
+            class="sidebar__collapse"
+            type="button"
+            data-action="collapse-sidebar"
+            aria-expanded="true"
+          >
+            <span class="sidebar__collapse-icon" aria-hidden="true">⮜</span>
+            <span class="sidebar__collapse-label" data-i18n="actions.sidebar.collapse">
+              Replier le menu
+            </span>
+          </button>
+        </div>
+        <div class="sidebar__welcome">
+          <span class="sidebar__welcome-title" data-i18n="welcome.title">Bienvenue</span>
+          <span class="sidebar__welcome-user" data-i18n="welcome.user">Utilisateur</span>
+        </div>
+        <nav class="sidebar__menu" aria-label="Navigation principale">
+          <div class="sidebar__group">
+            <p class="sidebar__heading" data-i18n="nav.modules.heading">Parcours RSE</p>
+            <div class="nav-item-wrapper">
+              <button
+                class="nav-item is-active"
+                type="button"
+                data-target="pilotage"
+                aria-pressed="true"
+              >
+                <span class="nav-item__bullet" aria-hidden="true">●</span>
+                <span class="nav-item__label" data-i18n="nav.modules.pilotage.label">
+                  Pilotage RSE
+                </span>
+              </button>
+              <div class="nav-item__popover" role="group">
+                <p class="nav-item__popover-title" data-i18n="nav.modules.popoverTitle">Accès rapide</p>
+                <ul class="nav-item__popover-list">
+                  <li data-i18n="nav.modules.pilotage.submodules.dashboard">Tableau de bord</li>
+                  <li data-i18n="nav.modules.pilotage.submodules.alerts">Alertes &amp; priorités</li>
+                  <li data-i18n="nav.modules.pilotage.submodules.materiality">Double matérialité</li>
+                  <li data-i18n="nav.modules.pilotage.submodules.roadmap">Feuille de route</li>
+                </ul>
+                <p class="nav-item__popover-note" data-i18n="nav.popover.hint">
+                  Survoler pour explorer le module complet.
+                </p>
+              </div>
+            </div>
+            <div class="nav-item-wrapper">
+              <button
+                class="nav-item"
+                type="button"
+                data-target="collecte"
+                aria-pressed="false"
+              >
+                <span class="nav-item__bullet" aria-hidden="true">●</span>
+                <span class="nav-item__label" data-i18n="nav.modules.collecte.label">
+                  Collecte &amp; campagnes
+                </span>
+              </button>
+              <div class="nav-item__popover" role="group">
+                <p class="nav-item__popover-title" data-i18n="nav.modules.popoverTitle">Accès rapide</p>
+                <ul class="nav-item__popover-list">
+                  <li data-i18n="nav.modules.collecte.submodules.campaigns">Campagnes</li>
+                  <li data-i18n="nav.modules.collecte.submodules.forms">Formulaires</li>
+                  <li data-i18n="nav.modules.collecte.submodules.controls">Contrôles qualité</li>
+                  <li data-i18n="nav.modules.collecte.submodules.contributors">Contributeurs</li>
+                </ul>
+                <p class="nav-item__popover-note" data-i18n="nav.popover.hint">
+                  Survoler pour explorer le module complet.
+                </p>
+              </div>
+            </div>
+            <div class="nav-item-wrapper">
+              <button
+                class="nav-item"
+                type="button"
+                data-target="analyse"
+                aria-pressed="false"
+              >
+                <span class="nav-item__bullet" aria-hidden="true">●</span>
+                <span class="nav-item__label" data-i18n="nav.modules.analyse.label">
+                  Analyses &amp; simulations
+                </span>
+              </button>
+              <div class="nav-item__popover" role="group">
+                <p class="nav-item__popover-title" data-i18n="nav.modules.popoverTitle">Accès rapide</p>
+                <ul class="nav-item__popover-list">
+                  <li data-i18n="nav.modules.analyse.submodules.carbon">Empreinte carbone</li>
+                  <li data-i18n="nav.modules.analyse.submodules.energy">Énergie &amp; sobriété</li>
+                  <li data-i18n="nav.modules.analyse.submodules.social">Social &amp; impact</li>
+                  <li data-i18n="nav.modules.analyse.submodules.governance">Gouvernance &amp; risques</li>
+                </ul>
+                <p class="nav-item__popover-note" data-i18n="nav.popover.hint">
+                  Survoler pour explorer le module complet.
+                </p>
+              </div>
+            </div>
+            <div class="nav-item-wrapper">
+              <button
+                class="nav-item"
+                type="button"
+                data-target="reporting"
+                aria-pressed="false"
+              >
+                <span class="nav-item__bullet" aria-hidden="true">●</span>
+                <span class="nav-item__label" data-i18n="nav.modules.reporting.label">
+                  Reporting &amp; communication
+                </span>
+              </button>
+              <div class="nav-item__popover" role="group">
+                <p class="nav-item__popover-title" data-i18n="nav.modules.popoverTitle">Accès rapide</p>
+                <ul class="nav-item__popover-list">
+                  <li data-i18n="nav.modules.reporting.submodules.csrd">Rapport CSRD</li>
+                  <li data-i18n="nav.modules.reporting.submodules.scorecards">Scorecards</li>
+                  <li data-i18n="nav.modules.reporting.submodules.exports">Exports &amp; API</li>
+                  <li data-i18n="nav.modules.reporting.submodules.stakeholders">Portail parties prenantes</li>
+                </ul>
+                <p class="nav-item__popover-note" data-i18n="nav.popover.hint">
+                  Survoler pour explorer le module complet.
+                </p>
+              </div>
+            </div>
+            <div class="nav-item-wrapper">
+              <button
+                class="nav-item"
+                type="button"
+                data-target="parametrage"
+                aria-pressed="false"
+              >
+                <span class="nav-item__bullet" aria-hidden="true">●</span>
+                <span class="nav-item__label" data-i18n="nav.modules.parametrage.label">
+                  Paramétrage &amp; administration
+                </span>
+              </button>
+              <div class="nav-item__popover" role="group">
+                <p class="nav-item__popover-title" data-i18n="nav.modules.popoverTitle">Accès rapide</p>
+                <ul class="nav-item__popover-list">
+                  <li data-i18n="nav.modules.parametrage.submodules.organization">Organisation</li>
+                  <li data-i18n="nav.modules.parametrage.submodules.roles">Utilisateurs &amp; rôles</li>
+                  <li data-i18n="nav.modules.parametrage.submodules.references">Référentiels</li>
+                  <li data-i18n="nav.modules.parametrage.submodules.security">Sécurité</li>
+                </ul>
+                <p class="nav-item__popover-note" data-i18n="nav.popover.hint">
+                  Survoler pour explorer le module complet.
+                </p>
+              </div>
+            </div>
+          </div>
+        </nav>
+        <footer class="sidebar__footer">
+          <button class="logout-button" type="button">
+            <span class="logout-button__icon" aria-hidden="true">⇦</span>
+            <span class="logout-button__label" data-i18n="buttons.logout">Déconnexion</span>
+          </button>
+        </footer>
+      </aside>
+      <main class="main" id="app-main">
+        <header class="topbar">
+          <div class="topbar__breadcrumbs">
+            <span class="breadcrumb" data-i18n="breadcrumbs.home">Accueil</span>
+            <span class="breadcrumb__divider" aria-hidden="true">/</span>
+            <span class="breadcrumb breadcrumb--current" data-role="current-section">Pilotage RSE</span>
+          </div>
+          <div class="topbar__actions">
+            <div class="language-switch" role="group" aria-label="Choix de la langue">
+              <button class="language-switch__btn is-active" type="button" data-lang="fr" aria-pressed="true">
+                FR
+              </button>
+              <button class="language-switch__btn" type="button" data-lang="en" aria-pressed="false">
+                EN
+              </button>
+            </div>
+            <button class="theme-switch" type="button" data-action="toggle-theme" aria-pressed="false">
+              <span class="theme-switch__icon" aria-hidden="true">🌙</span>
+              <span class="theme-switch__label" data-i18n="actions.theme.dark">Mode sombre</span>
+            </button>
+            <div class="user-badge" role="status">
+              <span class="user-badge__role" data-i18n="user.role">Admin</span>
+              <span class="user-badge__status" data-i18n="user.status">Connecté</span>
+            </div>
+          </div>
+        </header>
+
+        <section class="view is-active" id="pilotage">
+          <header class="view__header">
+            <h1 class="view__title" data-role="section-title" data-i18n="sections.pilotage.title">
+              Pilotage RSE
+            </h1>
+            <p class="view__intro" data-i18n="sections.pilotage.intro">
+              Tableau de bord consolidé pour suivre les indicateurs ESG et prioriser les actions.
+            </p>
+          </header>
+          <div class="card-grid">
+            <article class="info-card">
+              <h2 data-i18n="sections.pilotage.cards.dashboard.title">Tableau de bord exécutif</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.pilotage.cards.dashboard.items.overview">
+                  Indicateurs stratégiques multi-ODD et CSRD.
+                </li>
+                <li data-i18n="sections.pilotage.cards.dashboard.items.targets">
+                  Comparaison automatique aux objectifs et trajectoires.
+                </li>
+                <li data-i18n="sections.pilotage.cards.dashboard.items.materiality">
+                  Vue consolidée par entité, site ou périmètre.
+                </li>
+              </ul>
+            </article>
+            <article class="info-card">
+              <h2 data-i18n="sections.pilotage.cards.alerts.title">Alertes &amp; priorités</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.pilotage.cards.alerts.items.warnings">
+                  Alertes sur les écarts de performance et de conformité.
+                </li>
+                <li data-i18n="sections.pilotage.cards.alerts.items.workflow">
+                  Boîte d’actions assignées avec responsables et échéances.
+                </li>
+                <li data-i18n="sections.pilotage.cards.alerts.items.actions">
+                  Escalade automatique vers les comités de pilotage.
+                </li>
+              </ul>
+            </article>
+            <article class="info-card">
+              <h2 data-i18n="sections.pilotage.cards.roadmap.title">Feuille de route &amp; initiatives</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.pilotage.cards.roadmap.items.portfolio">
+                  Portfolio d’initiatives alignées sur les piliers ESG.
+                </li>
+                <li data-i18n="sections.pilotage.cards.roadmap.items.budget">
+                  Budgets, ROI et gains carbone suivis dans le temps.
+                </li>
+                <li data-i18n="sections.pilotage.cards.roadmap.items.followup">
+                  Synchronisation avec les plans d’actions métiers.
+                </li>
+              </ul>
+            </article>
+          </div>
+          <div class="callout" data-i18n="sections.pilotage.callout">
+            Les widgets se personnalisent par rôle et par périmètre pour proposer une navigation contextuelle.
+          </div>
+        </section>
+
+        <section class="view" id="collecte">
+          <header class="view__header">
+            <h1 class="view__title" data-role="section-title" data-i18n="sections.collecte.title">
+              Collecte &amp; campagnes
+            </h1>
+            <p class="view__intro" data-i18n="sections.collecte.intro">
+              Coordonner les contributeurs, la saisie de données et la qualité avant consolidation.
+            </p>
+          </header>
+          <div class="card-grid">
+            <article class="info-card">
+              <h2 data-i18n="sections.collecte.cards.campaigns.title">Campagnes &amp; formulaires</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.collecte.cards.campaigns.items.multi">
+                  Calendrier multi-sites avec rappels automatiques.
+                </li>
+                <li data-i18n="sections.collecte.cards.campaigns.items.forms">
+                  Formulaires dynamiques adaptés à chaque typologie de données.
+                </li>
+                <li data-i18n="sections.collecte.cards.campaigns.items.imports">
+                  Imports assistés depuis Excel, CSV ou API.
+                </li>
+              </ul>
+            </article>
+            <article class="info-card">
+              <h2 data-i18n="sections.collecte.cards.quality.title">Qualité &amp; validation</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.collecte.cards.quality.items.controls">
+                  Contrôles de cohérence et règles métiers paramétrables.
+                </li>
+                <li data-i18n="sections.collecte.cards.quality.items.workflow">
+                  Workflow d’approbation multi-niveaux avec notifications.
+                </li>
+                <li data-i18n="sections.collecte.cards.quality.items.audit">
+                  Journal d’audit et traçabilité complète par contribution.
+                </li>
+              </ul>
+            </article>
+            <article class="info-card">
+              <h2 data-i18n="sections.collecte.cards.integrations.title">Intégrations &amp; dépôts</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.collecte.cards.integrations.items.erp">
+                  Connecteurs ERP / IoT pour automatiser la collecte.
+                </li>
+                <li data-i18n="sections.collecte.cards.integrations.items.api">
+                  API sécurisée et webhooks pour synchronisations temps réel.
+                </li>
+                <li data-i18n="sections.collecte.cards.integrations.items.repository">
+                  Bibliothèque documentaire pour preuves et pièces jointes.
+                </li>
+              </ul>
+            </article>
+          </div>
+          <div class="callout" data-i18n="sections.collecte.callout">
+            Chaque contributeur dispose d’un espace dédié listant ses tâches et ses alertes.
+          </div>
+        </section>
+
+        <section class="view" id="analyse">
+          <header class="view__header">
+            <h1 class="view__title" data-role="section-title" data-i18n="sections.analyse.title">
+              Analyses &amp; simulations
+            </h1>
+            <p class="view__intro" data-i18n="sections.analyse.intro">
+              Croiser les données et référentiels pour identifier les leviers d’amélioration ESG.
+            </p>
+          </header>
+          <div class="analysis-grid">
+            <article class="analysis-card">
+              <h2 data-i18n="sections.analyse.blocks.carbon.title">Empreinte carbone</h2>
+              <ul class="analysis-list">
+                <li data-i18n="sections.analyse.blocks.carbon.items.scopes">
+                  Scopes 1, 2, 3 calculés avec facteurs certifiés.
+                </li>
+                <li data-i18n="sections.analyse.blocks.carbon.items.roadmap">
+                  Budgets carbone et trajectoires SBTi par périmètre.
+                </li>
+                <li data-i18n="sections.analyse.blocks.carbon.items.simulation">
+                  Simulations de scénarios et plans d’actions.
+                </li>
+              </ul>
+            </article>
+            <article class="analysis-card">
+              <h2 data-i18n="sections.analyse.blocks.energy.title">Énergie &amp; sobriété</h2>
+              <ul class="analysis-list">
+                <li data-i18n="sections.analyse.blocks.energy.items.monitoring">
+                  Suivi des consommations et intensités par site.
+                </li>
+                <li data-i18n="sections.analyse.blocks.energy.items.optimisation">
+                  Détection des dérives et optimisation en temps réel.
+                </li>
+                <li data-i18n="sections.analyse.blocks.energy.items.alerts">
+                  Alertes sur dépassements budgétaires et anomalies.
+                </li>
+              </ul>
+            </article>
+            <article class="analysis-card">
+              <h2 data-i18n="sections.analyse.blocks.social.title">Social &amp; impact</h2>
+              <ul class="analysis-list">
+                <li data-i18n="sections.analyse.blocks.social.items.engagement">
+                  Engagement collaborateurs, diversité et QVT.
+                </li>
+                <li data-i18n="sections.analyse.blocks.social.items.diversity">
+                  Suivi des programmes et indicateurs locaux.
+                </li>
+                <li data-i18n="sections.analyse.blocks.social.items.impact">
+                  Mesure de l’impact sociétal et des partenariats.
+                </li>
+              </ul>
+            </article>
+            <article class="analysis-card">
+              <h2 data-i18n="sections.analyse.blocks.governance.title">Gouvernance &amp; risques</h2>
+              <ul class="analysis-list">
+                <li data-i18n="sections.analyse.blocks.governance.items.risk">
+                  Cartographie des risques ESG et conformité.
+                </li>
+                <li data-i18n="sections.analyse.blocks.governance.items.compliance">
+                  Suivi des politiques, contrôles et audits.
+                </li>
+                <li data-i18n="sections.analyse.blocks.governance.items.committee">
+                  Préparation des comités et décisions clés.
+                </li>
+              </ul>
+            </article>
+          </div>
+          <p class="view__note" data-i18n="sections.analyse.note">
+            Les dashboards sont alignés avec les principaux référentiels (GRI, CSRD, ISO 26000, ODD…).
+          </p>
+        </section>
+
+        <section class="view" id="reporting">
+          <header class="view__header">
+            <h1 class="view__title" data-role="section-title" data-i18n="sections.reporting.title">
+              Reporting &amp; communication
+            </h1>
+            <p class="view__intro" data-i18n="sections.reporting.intro">
+              Automatiser la production des livrables internes et externes.
+            </p>
+          </header>
+          <div class="card-grid">
+            <article class="info-card">
+              <h2 data-i18n="sections.reporting.cards.csrd.title">Rapports réglementaires</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.reporting.cards.csrd.items.frameworks">
+                  Modèles CSRD, DPEF, GHG Protocol prêts à l’emploi.
+                </li>
+                <li data-i18n="sections.reporting.cards.csrd.items.narrative">
+                  Narratif collaboratif avec suggestions IA.
+                </li>
+                <li data-i18n="sections.reporting.cards.csrd.items.validation">
+                  Workflow de validation et gel des versions.
+                </li>
+              </ul>
+            </article>
+            <article class="info-card">
+              <h2 data-i18n="sections.reporting.cards.delivery.title">Diffusion &amp; exports</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.reporting.cards.delivery.items.exports">
+                  Exports PDF, Word, Excel et connecteur BI.
+                </li>
+                <li data-i18n="sections.reporting.cards.delivery.items.schedule">
+                  Planification des envois et signatures automatisées.
+                </li>
+                <li data-i18n="sections.reporting.cards.delivery.items.portal">
+                  Portail parties prenantes avec suivi des lectures.
+                </li>
+              </ul>
+            </article>
+          </div>
+          <div class="callout" data-i18n="sections.reporting.callout">
+            La double matérialité et les KPIs publiés restent synchronisés avec les modules d’analyse.
+          </div>
+        </section>
+
+        <section class="view" id="parametrage">
+          <header class="view__header">
+            <h1 class="view__title" data-role="section-title" data-i18n="sections.parametrage.title">
+              Paramétrage &amp; administration
+            </h1>
+            <p class="view__intro" data-i18n="sections.parametrage.intro">
+              Configurer la structure du groupe, les droits et les référentiels ESG.
+            </p>
+          </header>
+          <div class="card-grid">
+            <article class="info-card">
+              <h2 data-i18n="sections.parametrage.cards.organization.title">Organisation &amp; rôles</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.parametrage.cards.organization.items.structure">
+                  Hiérarchie entités, BU, sites et périmètres.
+                </li>
+                <li data-i18n="sections.parametrage.cards.organization.items.entitlements">
+                  Gestion des rôles, délégations et accès temporaires.
+                </li>
+                <li data-i18n="sections.parametrage.cards.organization.items.workflows">
+                  Scénarios de workflows par module.
+                </li>
+              </ul>
+            </article>
+            <article class="info-card">
+              <h2 data-i18n="sections.parametrage.cards.security.title">Référentiels &amp; sécurité</h2>
+              <ul class="info-list">
+                <li data-i18n="sections.parametrage.cards.security.items.policies">
+                  Paramétrage des politiques, objectifs et alertes.
+                </li>
+                <li data-i18n="sections.parametrage.cards.security.items.references">
+                  Gestion des référentiels ESG et des traductions.
+                </li>
+                <li data-i18n="sections.parametrage.cards.security.items.localization">
+                  Audit des accès, SSO et journalisation.
+                </li>
+              </ul>
+            </article>
+          </div>
+          <div class="callout" data-i18n="sections.parametrage.callout">
+            Les paramètres se dupliquent par environnement (test, production) pour sécuriser les déploiements.
+          </div>
+        </section>
+      </main>
+    </div>
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,408 @@
+const translations = {
+  fr: {
+    'brand.title': 'Ecopilot',
+    'brand.subtitle': 'Pilotage ESG',
+    'welcome.title': 'Bienvenue',
+    'welcome.user': 'Utilisateur',
+    'actions.sidebar.collapse': 'Replier le menu',
+    'actions.sidebar.expand': 'Déployer le menu',
+    'actions.theme.dark': 'Mode sombre',
+    'actions.theme.light': 'Mode clair',
+    'buttons.logout': 'Déconnexion',
+    'breadcrumbs.home': 'Accueil',
+    'user.role': 'Admin',
+    'user.status': 'Connecté',
+    'nav.modules.heading': 'Parcours RSE',
+    'nav.modules.popoverTitle': 'Accès rapide',
+    'nav.modules.pilotage.label': 'Pilotage RSE',
+    'nav.modules.pilotage.submodules.dashboard': 'Tableau de bord',
+    'nav.modules.pilotage.submodules.alerts': 'Alertes & priorités',
+    'nav.modules.pilotage.submodules.materiality': 'Double matérialité',
+    'nav.modules.pilotage.submodules.roadmap': 'Feuille de route',
+    'nav.modules.collecte.label': 'Collecte & campagnes',
+    'nav.modules.collecte.submodules.campaigns': 'Campagnes',
+    'nav.modules.collecte.submodules.forms': 'Formulaires',
+    'nav.modules.collecte.submodules.controls': 'Contrôles qualité',
+    'nav.modules.collecte.submodules.contributors': 'Contributeurs',
+    'nav.modules.analyse.label': 'Analyses & simulations',
+    'nav.modules.analyse.submodules.carbon': 'Empreinte carbone',
+    'nav.modules.analyse.submodules.energy': 'Énergie & sobriété',
+    'nav.modules.analyse.submodules.social': 'Social & impact',
+    'nav.modules.analyse.submodules.governance': 'Gouvernance & risques',
+    'nav.modules.reporting.label': 'Reporting & communication',
+    'nav.modules.reporting.submodules.csrd': 'Rapport CSRD',
+    'nav.modules.reporting.submodules.scorecards': 'Scorecards',
+    'nav.modules.reporting.submodules.exports': 'Exports & API',
+    'nav.modules.reporting.submodules.stakeholders': 'Portail parties prenantes',
+    'nav.modules.parametrage.label': 'Paramétrage & administration',
+    'nav.modules.parametrage.submodules.organization': 'Organisation',
+    'nav.modules.parametrage.submodules.roles': 'Utilisateurs & rôles',
+    'nav.modules.parametrage.submodules.references': 'Référentiels',
+    'nav.modules.parametrage.submodules.security': 'Sécurité',
+    'nav.popover.hint': 'Survoler pour explorer le module complet.',
+    'sections.pilotage.title': 'Pilotage RSE',
+    'sections.pilotage.intro': 'Tableau de bord consolidé pour suivre les indicateurs ESG et prioriser les actions.',
+    'sections.pilotage.cards.dashboard.title': 'Tableau de bord exécutif',
+    'sections.pilotage.cards.dashboard.items.overview': 'Indicateurs stratégiques multi-ODD et CSRD.',
+    'sections.pilotage.cards.dashboard.items.targets': 'Comparaison automatique aux objectifs et trajectoires.',
+    'sections.pilotage.cards.dashboard.items.materiality': 'Vue consolidée par entité, site ou périmètre.',
+    'sections.pilotage.cards.alerts.title': 'Alertes & priorités',
+    'sections.pilotage.cards.alerts.items.warnings': 'Alertes sur les écarts de performance et de conformité.',
+    'sections.pilotage.cards.alerts.items.workflow': 'Boîte d’actions assignées avec responsables et échéances.',
+    'sections.pilotage.cards.alerts.items.actions': 'Escalade automatique vers les comités de pilotage.',
+    'sections.pilotage.cards.roadmap.title': 'Feuille de route & initiatives',
+    'sections.pilotage.cards.roadmap.items.portfolio': 'Portfolio d’initiatives alignées sur les piliers ESG.',
+    'sections.pilotage.cards.roadmap.items.budget': 'Budgets, ROI et gains carbone suivis dans le temps.',
+    'sections.pilotage.cards.roadmap.items.followup': 'Synchronisation avec les plans d’actions métiers.',
+    'sections.pilotage.callout': 'Les widgets se personnalisent par rôle et par périmètre pour proposer une navigation contextuelle.',
+    'sections.collecte.title': 'Collecte & campagnes',
+    'sections.collecte.intro': 'Coordonner les contributeurs, la saisie de données et la qualité avant consolidation.',
+    'sections.collecte.cards.campaigns.title': 'Campagnes & formulaires',
+    'sections.collecte.cards.campaigns.items.multi': 'Calendrier multi-sites avec rappels automatiques.',
+    'sections.collecte.cards.campaigns.items.forms': 'Formulaires dynamiques adaptés à chaque typologie de données.',
+    'sections.collecte.cards.campaigns.items.imports': 'Imports assistés depuis Excel, CSV ou API.',
+    'sections.collecte.cards.quality.title': 'Qualité & validation',
+    'sections.collecte.cards.quality.items.controls': 'Contrôles de cohérence et règles métiers paramétrables.',
+    'sections.collecte.cards.quality.items.workflow': 'Workflow d’approbation multi-niveaux avec notifications.',
+    'sections.collecte.cards.quality.items.audit': 'Journal d’audit et traçabilité complète par contribution.',
+    'sections.collecte.cards.integrations.title': 'Intégrations & dépôts',
+    'sections.collecte.cards.integrations.items.erp': 'Connecteurs ERP / IoT pour automatiser la collecte.',
+    'sections.collecte.cards.integrations.items.api': 'API sécurisée et webhooks pour synchronisations temps réel.',
+    'sections.collecte.cards.integrations.items.repository': 'Bibliothèque documentaire pour preuves et pièces jointes.',
+    'sections.collecte.callout': 'Chaque contributeur dispose d’un espace dédié listant ses tâches et ses alertes.',
+    'sections.analyse.title': 'Analyses & simulations',
+    'sections.analyse.intro': 'Croiser les données et référentiels pour identifier les leviers d’amélioration ESG.',
+    'sections.analyse.blocks.carbon.title': 'Empreinte carbone',
+    'sections.analyse.blocks.carbon.items.scopes': 'Scopes 1, 2, 3 calculés avec facteurs certifiés.',
+    'sections.analyse.blocks.carbon.items.roadmap': 'Budgets carbone et trajectoires SBTi par périmètre.',
+    'sections.analyse.blocks.carbon.items.simulation': 'Simulations de scénarios et plans d’actions.',
+    'sections.analyse.blocks.energy.title': 'Énergie & sobriété',
+    'sections.analyse.blocks.energy.items.monitoring': 'Suivi des consommations et intensités par site.',
+    'sections.analyse.blocks.energy.items.optimisation': 'Détection des dérives et optimisation en temps réel.',
+    'sections.analyse.blocks.energy.items.alerts': 'Alertes sur dépassements budgétaires et anomalies.',
+    'sections.analyse.blocks.social.title': 'Social & impact',
+    'sections.analyse.blocks.social.items.engagement': 'Engagement collaborateurs, diversité et QVT.',
+    'sections.analyse.blocks.social.items.diversity': 'Suivi des programmes et indicateurs locaux.',
+    'sections.analyse.blocks.social.items.impact': 'Mesure de l’impact sociétal et des partenariats.',
+    'sections.analyse.blocks.governance.title': 'Gouvernance & risques',
+    'sections.analyse.blocks.governance.items.risk': 'Cartographie des risques ESG et conformité.',
+    'sections.analyse.blocks.governance.items.compliance': 'Suivi des politiques, contrôles et audits.',
+    'sections.analyse.blocks.governance.items.committee': 'Préparation des comités et décisions clés.',
+    'sections.analyse.note': 'Les dashboards sont alignés avec les principaux référentiels (GRI, CSRD, ISO 26000, ODD…).',
+    'sections.reporting.title': 'Reporting & communication',
+    'sections.reporting.intro': 'Automatiser la production des livrables internes et externes.',
+    'sections.reporting.cards.csrd.title': 'Rapports réglementaires',
+    'sections.reporting.cards.csrd.items.frameworks': 'Modèles CSRD, DPEF, GHG Protocol prêts à l’emploi.',
+    'sections.reporting.cards.csrd.items.narrative': 'Narratif collaboratif avec suggestions IA.',
+    'sections.reporting.cards.csrd.items.validation': 'Workflow de validation et gel des versions.',
+    'sections.reporting.cards.delivery.title': 'Diffusion & exports',
+    'sections.reporting.cards.delivery.items.exports': 'Exports PDF, Word, Excel et connecteur BI.',
+    'sections.reporting.cards.delivery.items.schedule': 'Planification des envois et signatures automatisées.',
+    'sections.reporting.cards.delivery.items.portal': 'Portail parties prenantes avec suivi des lectures.',
+    'sections.reporting.callout': 'La double matérialité et les KPIs publiés restent synchronisés avec les modules d’analyse.',
+    'sections.parametrage.title': 'Paramétrage & administration',
+    'sections.parametrage.intro': 'Configurer la structure du groupe, les droits et les référentiels ESG.',
+    'sections.parametrage.cards.organization.title': 'Organisation & rôles',
+    'sections.parametrage.cards.organization.items.structure': 'Hiérarchie entités, BU, sites et périmètres.',
+    'sections.parametrage.cards.organization.items.entitlements': 'Gestion des rôles, délégations et accès temporaires.',
+    'sections.parametrage.cards.organization.items.workflows': 'Scénarios de workflows par module.',
+    'sections.parametrage.cards.security.title': 'Référentiels & sécurité',
+    'sections.parametrage.cards.security.items.policies': 'Paramétrage des politiques, objectifs et alertes.',
+    'sections.parametrage.cards.security.items.references': 'Gestion des référentiels ESG et des traductions.',
+    'sections.parametrage.cards.security.items.localization': 'Audit des accès, SSO et journalisation.',
+    'sections.parametrage.callout': 'Les paramètres se dupliquent par environnement (test, production) pour sécuriser les déploiements.'
+  },
+  en: {
+    'brand.title': 'Ecopilot',
+    'brand.subtitle': 'ESG steering',
+    'welcome.title': 'Welcome',
+    'welcome.user': 'User',
+    'actions.sidebar.collapse': 'Collapse menu',
+    'actions.sidebar.expand': 'Expand menu',
+    'actions.theme.dark': 'Dark mode',
+    'actions.theme.light': 'Light mode',
+    'buttons.logout': 'Log out',
+    'breadcrumbs.home': 'Home',
+    'user.role': 'Admin',
+    'user.status': 'Online',
+    'nav.modules.heading': 'ESG journey',
+    'nav.modules.popoverTitle': 'Quick access',
+    'nav.modules.pilotage.label': 'ESG steering',
+    'nav.modules.pilotage.submodules.dashboard': 'Executive dashboard',
+    'nav.modules.pilotage.submodules.alerts': 'Alerts & priorities',
+    'nav.modules.pilotage.submodules.materiality': 'Double materiality',
+    'nav.modules.pilotage.submodules.roadmap': 'Roadmap',
+    'nav.modules.collecte.label': 'Data collection',
+    'nav.modules.collecte.submodules.campaigns': 'Campaigns',
+    'nav.modules.collecte.submodules.forms': 'Forms',
+    'nav.modules.collecte.submodules.controls': 'Quality controls',
+    'nav.modules.collecte.submodules.contributors': 'Contributors',
+    'nav.modules.analyse.label': 'Analysis & simulations',
+    'nav.modules.analyse.submodules.carbon': 'Carbon footprint',
+    'nav.modules.analyse.submodules.energy': 'Energy & efficiency',
+    'nav.modules.analyse.submodules.social': 'People & impact',
+    'nav.modules.analyse.submodules.governance': 'Governance & risks',
+    'nav.modules.reporting.label': 'Reporting & communication',
+    'nav.modules.reporting.submodules.csrd': 'CSRD report',
+    'nav.modules.reporting.submodules.scorecards': 'Scorecards',
+    'nav.modules.reporting.submodules.exports': 'Exports & APIs',
+    'nav.modules.reporting.submodules.stakeholders': 'Stakeholder portal',
+    'nav.modules.parametrage.label': 'Settings & administration',
+    'nav.modules.parametrage.submodules.organization': 'Organisation',
+    'nav.modules.parametrage.submodules.roles': 'Users & roles',
+    'nav.modules.parametrage.submodules.references': 'Reference data',
+    'nav.modules.parametrage.submodules.security': 'Security',
+    'nav.popover.hint': 'Hover to explore the full module.',
+    'sections.pilotage.title': 'ESG steering',
+    'sections.pilotage.intro': 'A consolidated cockpit to monitor sustainability KPIs and prioritise actions.',
+    'sections.pilotage.cards.dashboard.title': 'Executive dashboard',
+    'sections.pilotage.cards.dashboard.items.overview': 'Strategic KPIs mapped to SDGs and CSRD.',
+    'sections.pilotage.cards.dashboard.items.targets': 'Automatic comparisons versus targets and trajectories.',
+    'sections.pilotage.cards.dashboard.items.materiality': 'Consolidated view by entity, site or scope.',
+    'sections.pilotage.cards.alerts.title': 'Alerts & priorities',
+    'sections.pilotage.cards.alerts.items.warnings': 'Performance and compliance alerts triggered automatically.',
+    'sections.pilotage.cards.alerts.items.workflow': 'Action inbox with owners and due dates.',
+    'sections.pilotage.cards.alerts.items.actions': 'Escalation to steering committees when thresholds are met.',
+    'sections.pilotage.cards.roadmap.title': 'Roadmap & initiatives',
+    'sections.pilotage.cards.roadmap.items.portfolio': 'Initiative portfolio aligned with ESG pillars.',
+    'sections.pilotage.cards.roadmap.items.budget': 'Budgets, ROI and carbon savings tracked over time.',
+    'sections.pilotage.cards.roadmap.items.followup': 'Sync with business action plans and OKRs.',
+    'sections.pilotage.callout': 'Widgets adapt to each role and scope to provide contextual navigation.',
+    'sections.collecte.title': 'Data collection',
+    'sections.collecte.intro': 'Coordinate contributors, data entry and quality before consolidation.',
+    'sections.collecte.cards.campaigns.title': 'Campaigns & forms',
+    'sections.collecte.cards.campaigns.items.multi': 'Multi-site calendar with automated reminders.',
+    'sections.collecte.cards.campaigns.items.forms': 'Dynamic forms tailored to each data category.',
+    'sections.collecte.cards.campaigns.items.imports': 'Guided imports from spreadsheets or APIs.',
+    'sections.collecte.cards.quality.title': 'Quality & validation',
+    'sections.collecte.cards.quality.items.controls': 'Consistency checks and configurable business rules.',
+    'sections.collecte.cards.quality.items.workflow': 'Multi-level approval workflow with notifications.',
+    'sections.collecte.cards.quality.items.audit': 'Complete audit trail and traceability per submission.',
+    'sections.collecte.cards.integrations.title': 'Integrations & vault',
+    'sections.collecte.cards.integrations.items.erp': 'ERP and IoT connectors to automate collection.',
+    'sections.collecte.cards.integrations.items.api': 'Secure API and webhooks for real-time sync.',
+    'sections.collecte.cards.integrations.items.repository': 'Document repository for evidence and attachments.',
+    'sections.collecte.callout': 'Each contributor accesses a personalised workspace listing tasks and alerts.',
+    'sections.analyse.title': 'Analysis & simulations',
+    'sections.analyse.intro': 'Combine datasets and frameworks to identify ESG improvement levers.',
+    'sections.analyse.blocks.carbon.title': 'Carbon footprint',
+    'sections.analyse.blocks.carbon.items.scopes': 'Scopes 1, 2, 3 calculated with certified factors.',
+    'sections.analyse.blocks.carbon.items.roadmap': 'Carbon budgets and SBTi trajectories per scope.',
+    'sections.analyse.blocks.carbon.items.simulation': 'Scenario simulations and action plans.',
+    'sections.analyse.blocks.energy.title': 'Energy & efficiency',
+    'sections.analyse.blocks.energy.items.monitoring': 'Consumption and intensity tracking per site.',
+    'sections.analyse.blocks.energy.items.optimisation': 'Real-time drift detection and optimisation.',
+    'sections.analyse.blocks.energy.items.alerts': 'Alerts on budget overruns and anomalies.',
+    'sections.analyse.blocks.social.title': 'People & impact',
+    'sections.analyse.blocks.social.items.engagement': 'Engagement, diversity and wellbeing indicators.',
+    'sections.analyse.blocks.social.items.diversity': 'Programme monitoring with local indicators.',
+    'sections.analyse.blocks.social.items.impact': 'Measurement of societal impact and partnerships.',
+    'sections.analyse.blocks.governance.title': 'Governance & risks',
+    'sections.analyse.blocks.governance.items.risk': 'ESG risk and compliance mapping.',
+    'sections.analyse.blocks.governance.items.compliance': 'Policies, controls and audit follow-up.',
+    'sections.analyse.blocks.governance.items.committee': 'Preparation for committees and key decisions.',
+    'sections.analyse.note': 'Dashboards are aligned with major frameworks (GRI, CSRD, ISO 26000, SDGs…).',
+    'sections.reporting.title': 'Reporting & communication',
+    'sections.reporting.intro': 'Automate the production of internal and external deliverables.',
+    'sections.reporting.cards.csrd.title': 'Regulatory reports',
+    'sections.reporting.cards.csrd.items.frameworks': 'Ready-to-use CSRD, NFRD and GHG Protocol templates.',
+    'sections.reporting.cards.csrd.items.narrative': 'Collaborative narrative with AI-assisted suggestions.',
+    'sections.reporting.cards.csrd.items.validation': 'Validation workflow with version freeze.',
+    'sections.reporting.cards.delivery.title': 'Distribution & exports',
+    'sections.reporting.cards.delivery.items.exports': 'PDF, Word, Excel exports and BI connector.',
+    'sections.reporting.cards.delivery.items.schedule': 'Scheduling, signatures and automated delivery.',
+    'sections.reporting.cards.delivery.items.portal': 'Stakeholder portal with reading analytics.',
+    'sections.reporting.callout': 'Double materiality and published KPIs stay synchronised with analysis modules.',
+    'sections.parametrage.title': 'Settings & administration',
+    'sections.parametrage.intro': 'Configure the organisation, permissions and ESG reference data.',
+    'sections.parametrage.cards.organization.title': 'Organisation & roles',
+    'sections.parametrage.cards.organization.items.structure': 'Hierarchy for entities, BUs, sites and scopes.',
+    'sections.parametrage.cards.organization.items.entitlements': 'Role management, delegations and temporary access.',
+    'sections.parametrage.cards.organization.items.workflows': 'Workflow scenarios per module.',
+    'sections.parametrage.cards.security.title': 'Reference data & security',
+    'sections.parametrage.cards.security.items.policies': 'Policies, targets and alert thresholds.',
+    'sections.parametrage.cards.security.items.references': 'ESG frameworks, taxonomies and translations.',
+    'sections.parametrage.cards.security.items.localization': 'Access audit, SSO and logging.',
+    'sections.parametrage.callout': 'Settings can be cloned between environments to secure roll-outs.'
+  }
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  const root = document.documentElement;
+  const app = document.querySelector('.app');
+  const navButtons = Array.from(document.querySelectorAll('.nav-item'));
+  const sections = Array.from(document.querySelectorAll('.view'));
+  const crumbCurrent = document.querySelector('[data-role="current-section"]');
+  const languageButtons = Array.from(document.querySelectorAll('.language-switch__btn'));
+  const themeToggle = document.querySelector('[data-action="toggle-theme"]');
+  const sidebarToggle = document.querySelector('[data-action="collapse-sidebar"]');
+
+  const storageKeys = {
+    language: 'ecopilot:language',
+    theme: 'ecopilot:theme',
+    sidebar: 'ecopilot:sidebar'
+  };
+
+  const storage = {
+    get(key) {
+      try {
+        return window.localStorage.getItem(key);
+      } catch (error) {
+        return null;
+      }
+    },
+    set(key, value) {
+      try {
+        window.localStorage.setItem(key, value);
+      } catch (error) {
+        // ignore storage errors
+      }
+    }
+  };
+
+  let activeLanguage = 'fr';
+
+  const getDictionary = (lang) => translations[lang] ?? translations.fr;
+
+  const translateKey = (key) => {
+    const dictionary = getDictionary(activeLanguage);
+    return dictionary[key] ?? key;
+  };
+
+  const updateBreadcrumb = () => {
+    if (!crumbCurrent) return;
+    const activeSection = sections.find((section) => section.classList.contains('is-active'));
+    if (!activeSection) return;
+    const title = activeSection.querySelector('[data-role="section-title"]');
+    if (!title) return;
+    crumbCurrent.textContent = title.textContent.trim();
+  };
+
+  const applyTranslations = () => {
+    const dictionary = getDictionary(activeLanguage);
+    document.querySelectorAll('[data-i18n]').forEach((element) => {
+      const key = element.dataset.i18n;
+      if (!key) return;
+      const value = dictionary[key];
+      if (value === undefined) return;
+      element.innerHTML = value;
+    });
+  };
+
+  const setTheme = (theme) => {
+    const resolved = theme === 'dark' ? 'dark' : 'light';
+    document.body.setAttribute('data-theme', resolved);
+    if (themeToggle) {
+      themeToggle.setAttribute('aria-pressed', String(resolved === 'dark'));
+      const icon = themeToggle.querySelector('.theme-switch__icon');
+      if (icon) {
+        icon.textContent = resolved === 'dark' ? '☀️' : '🌙';
+      }
+      const label = themeToggle.querySelector('.theme-switch__label');
+      if (label) {
+        const key = resolved === 'dark' ? 'actions.theme.light' : 'actions.theme.dark';
+        label.innerHTML = translateKey(key);
+      }
+    }
+    storage.set(storageKeys.theme, resolved);
+  };
+
+  const toggleTheme = () => {
+    const current = document.body.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+    const next = current === 'dark' ? 'light' : 'dark';
+    setTheme(next);
+  };
+
+  const setSidebarState = (collapsed) => {
+    if (!app) return;
+    app.classList.toggle('is-sidebar-collapsed', collapsed);
+    if (sidebarToggle) {
+      sidebarToggle.setAttribute('aria-expanded', String(!collapsed));
+      const label = sidebarToggle.querySelector('.sidebar__collapse-label');
+      if (label) {
+        const key = collapsed ? 'actions.sidebar.expand' : 'actions.sidebar.collapse';
+        label.innerHTML = translateKey(key);
+      }
+    }
+    storage.set(storageKeys.sidebar, collapsed ? 'collapsed' : 'expanded');
+  };
+
+  const activateSection = (targetId) => {
+    const target = sections.find((section) => section.id === targetId);
+    if (!target) return;
+    sections.forEach((section) => {
+      section.classList.toggle('is-active', section === target);
+    });
+    navButtons.forEach((button) => {
+      const isActive = button.dataset.target === targetId;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-pressed', String(isActive));
+    });
+    updateBreadcrumb();
+  };
+
+  const applyLanguage = (lang) => {
+    activeLanguage = translations[lang] ? lang : 'fr';
+    root.setAttribute('lang', activeLanguage);
+    applyTranslations();
+    languageButtons.forEach((button) => {
+      const isActive = button.dataset.lang === activeLanguage;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-pressed', String(isActive));
+    });
+    setTheme(document.body.getAttribute('data-theme'));
+    setSidebarState(app?.classList.contains('is-sidebar-collapsed'));
+    storage.set(storageKeys.language, activeLanguage);
+    updateBreadcrumb();
+  };
+
+  navButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const targetId = button.dataset.target;
+      if (!targetId) return;
+      activateSection(targetId);
+    });
+    button.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        button.click();
+      }
+    });
+  });
+
+  languageButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const lang = button.dataset.lang;
+      applyLanguage(lang);
+    });
+  });
+
+  if (themeToggle) {
+    themeToggle.addEventListener('click', () => {
+      toggleTheme();
+    });
+  }
+
+  if (sidebarToggle) {
+    sidebarToggle.addEventListener('click', () => {
+      const isCollapsed = app?.classList.contains('is-sidebar-collapsed');
+      setSidebarState(!isCollapsed);
+    });
+  }
+
+  const storedLanguage = storage.get(storageKeys.language);
+  const storedTheme = storage.get(storageKeys.theme);
+  const storedSidebar = storage.get(storageKeys.sidebar);
+
+  if (storedSidebar === 'collapsed') {
+    setSidebarState(true);
+  } else {
+    setSidebarState(false);
+  }
+
+  applyLanguage(storedLanguage ?? activeLanguage);
+  setTheme(storedTheme ?? document.body.getAttribute('data-theme'));
+
+  const defaultSection = sections.find((section) => section.classList.contains('is-active'));
+  activateSection(defaultSection?.id ?? 'pilotage');
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,827 @@
+:root {
+  --font-family: 'Inter', sans-serif;
+  --color-bg: #f4f6fb;
+  --color-surface: #ffffff;
+  --color-surface-soft: #f0f4ff;
+  --color-surface-muted: #f7f9fc;
+  --color-text: #1f2937;
+  --color-text-muted: #4b5563;
+  --color-border: #d8dee9;
+  --color-accent: #2f6fed;
+  --color-accent-soft: rgba(47, 111, 237, 0.12);
+  --shadow-sm: 0 1px 3px rgba(15, 23, 42, 0.08);
+  --shadow-md: 0 18px 40px rgba(15, 23, 42, 0.12);
+  --radius-lg: 20px;
+  --radius-md: 14px;
+  --radius-sm: 10px;
+  --transition-base: 0.25s ease;
+}
+
+body[data-theme='dark'] {
+  --color-bg: #111827;
+  --color-surface: #1f2937;
+  --color-surface-soft: #16213a;
+  --color-surface-muted: #0f172a;
+  --color-text: #f9fafb;
+  --color-text-muted: #cbd5f5;
+  --color-border: rgba(148, 163, 184, 0.24);
+  --color-accent: #60a5fa;
+  --color-accent-soft: rgba(96, 165, 250, 0.18);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 20px 44px rgba(8, 13, 23, 0.5);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-family);
+  background: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+button {
+  font: inherit;
+  color: inherit;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+button:focus-visible,
+.language-switch__btn:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.app {
+  display: flex;
+  min-height: 100vh;
+  background: var(--color-bg);
+}
+
+.sidebar {
+  width: 320px;
+  background: var(--color-surface);
+  border-right: 1px solid var(--color-border);
+  padding: 28px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  transition: width var(--transition-base), padding var(--transition-base);
+}
+
+.sidebar__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.sidebar__brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.sidebar__logo {
+  font-size: 2rem;
+}
+
+.sidebar__brand-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sidebar__brand-title {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.95rem;
+}
+
+.sidebar__brand-subtitle {
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+  letter-spacing: 0.03em;
+}
+
+.sidebar__collapse {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-soft);
+  border: 1px solid transparent;
+  color: var(--color-text);
+  transition: background var(--transition-base), color var(--transition-base);
+}
+
+.sidebar__collapse:hover {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.sidebar__collapse-icon {
+  font-size: 1rem;
+  transition: transform var(--transition-base);
+}
+
+.sidebar__welcome {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-soft);
+  color: var(--color-text);
+}
+
+.sidebar__welcome-title {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+}
+
+.sidebar__welcome-user {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.sidebar__menu {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.sidebar__group {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sidebar__heading {
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.nav-item-wrapper {
+  position: relative;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
+  text-align: left;
+  transition: background var(--transition-base), box-shadow var(--transition-base), color var(--transition-base);
+}
+
+.nav-item__bullet {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  font-size: 0.7rem;
+  background: var(--color-surface-muted);
+  color: var(--color-text-muted);
+}
+
+.nav-item:hover {
+  background: var(--color-surface-soft);
+}
+
+.nav-item.is-active {
+  background: var(--color-accent);
+  color: #fff;
+  box-shadow: var(--shadow-sm);
+}
+
+.nav-item.is-active .nav-item__bullet {
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}
+
+.nav-item__popover {
+  position: absolute;
+  top: 50%;
+  left: calc(100% + 12px);
+  transform: translate3d(-8px, -50%, 0);
+  width: clamp(180px, 24vw, 240px);
+  padding: 12px 14px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  box-shadow: var(--shadow-md);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition-base), transform var(--transition-base);
+  z-index: 20;
+}
+
+.nav-item__popover::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 100%;
+  transform: translateY(-50%) rotate(45deg);
+  width: 12px;
+  height: 12px;
+  background: var(--color-surface);
+  border-left: 1px solid var(--color-border);
+  border-top: 1px solid var(--color-border);
+  transform-origin: center;
+}
+
+.nav-item-wrapper:hover .nav-item__popover,
+.nav-item-wrapper:focus-within .nav-item__popover {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate3d(0, -50%, 0);
+}
+
+.nav-item__popover-title {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.nav-item__popover-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 0;
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.nav-item__popover-note {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.sidebar__footer {
+  margin-top: auto;
+}
+
+.logout-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-soft);
+  color: var(--color-text);
+  transition: background var(--transition-base), color var(--transition-base);
+}
+
+.logout-button__icon {
+  font-size: 0.95rem;
+}
+
+.logout-button:hover {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: var(--color-bg);
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  padding: 24px 32px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.topbar__breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+.breadcrumb--current {
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.topbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.language-switch {
+  display: inline-flex;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--color-surface-muted);
+}
+
+.language-switch__btn {
+  padding: 6px 12px;
+  font-size: 0.85rem;
+  border-right: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  background: transparent;
+  transition: background var(--transition-base), color var(--transition-base);
+}
+
+.language-switch__btn:last-child {
+  border-right: none;
+}
+
+.language-switch__btn.is-active {
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.theme-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  padding: 8px 12px;
+  background: var(--color-surface-muted);
+  transition: background var(--transition-base), color var(--transition-base);
+}
+
+.theme-switch:hover {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.theme-switch__icon {
+  font-size: 1rem;
+}
+
+.user-badge {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  font-size: 0.8rem;
+  min-width: 110px;
+}
+
+.user-badge__role {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.user-badge__status {
+  font-size: 0.9rem;
+}
+
+.view {
+  display: none;
+  padding: 36px 48px 60px;
+  overflow-y: auto;
+}
+
+.view.is-active {
+  display: block;
+}
+
+.view__header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 28px;
+}
+
+.view__title {
+  margin: 0;
+  font-size: 1.85rem;
+  font-weight: 700;
+}
+
+.view__intro {
+  margin: 0;
+  color: var(--color-text-muted);
+  max-width: 760px;
+}
+
+.overview-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.overview-column {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.overview-column__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.overview-column__note {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+.overview-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.overview-list li {
+  position: relative;
+  padding-left: 18px;
+}
+
+.overview-list li::before {
+  content: '';
+  position: absolute;
+  top: 8px;
+  left: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  opacity: 0.65;
+}
+
+.overview-list--tags {
+  flex-wrap: wrap;
+  flex-direction: row;
+  gap: 10px;
+}
+
+.overview-list--tags li {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.overview-list--tags li::before {
+  display: none;
+}
+
+.plus-grid {
+  margin-top: auto;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.plus-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px dashed var(--color-border);
+  background: var(--color-surface-muted);
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.plus-card span:first-child {
+  font-size: 1.5rem;
+  color: var(--color-accent);
+}
+
+.view__note {
+  margin-top: 28px;
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+  background: var(--color-accent-soft);
+  border-left: 4px solid var(--color-accent);
+  padding: 14px 18px;
+  border-radius: var(--radius-md);
+}
+
+.card-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.info-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: var(--shadow-sm);
+  min-height: 220px;
+}
+
+.info-card h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.info-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  color: var(--color-text);
+}
+
+.info-list li {
+  position: relative;
+  padding-left: 18px;
+  font-size: 0.95rem;
+}
+
+.info-list li::before {
+  content: '';
+  position: absolute;
+  top: 8px;
+  left: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 3px;
+  background: var(--color-accent);
+  opacity: 0.65;
+}
+
+.callout {
+  margin-top: 28px;
+  padding: 18px 20px;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-soft);
+  color: var(--color-text);
+  border-left: 4px solid var(--color-accent);
+  box-shadow: var(--shadow-sm);
+}
+
+.app.is-sidebar-collapsed .sidebar {
+  width: 92px;
+  padding: 28px 12px;
+}
+
+.app.is-sidebar-collapsed .sidebar__brand-text,
+.app.is-sidebar-collapsed .sidebar__welcome,
+.app.is-sidebar-collapsed .sidebar__heading,
+.app.is-sidebar-collapsed .sidebar__collapse-label,
+.app.is-sidebar-collapsed .logout-button__label {
+  display: none;
+}
+
+.app.is-sidebar-collapsed .sidebar__collapse-icon {
+  transform: rotate(180deg);
+}
+
+.app.is-sidebar-collapsed .nav-item {
+  justify-content: center;
+  padding: 12px 10px;
+}
+
+.app.is-sidebar-collapsed .nav-item__label {
+  display: none;
+}
+
+.app.is-sidebar-collapsed .nav-item__bullet {
+  width: 30px;
+  height: 30px;
+  font-size: 0.8rem;
+}
+
+.app.is-sidebar-collapsed .logout-button {
+  justify-content: center;
+}
+
+@media (max-width: 1280px) {
+  .overview-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 960px) {
+  .app {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    width: 100%;
+    flex-direction: row;
+    align-items: flex-start;
+    padding: 20px;
+    gap: 20px;
+    overflow-x: auto;
+  }
+
+  .sidebar__top {
+    flex-direction: row;
+    flex: 1;
+  }
+
+  .sidebar__menu {
+    flex-direction: row;
+    gap: 24px;
+    flex: 2;
+  }
+
+  .sidebar__group {
+    min-width: 200px;
+  }
+
+  .sidebar__footer {
+    display: none;
+  }
+
+  .main {
+    min-height: calc(100vh - 220px);
+  }
+
+  .topbar {
+    position: static;
+  }
+
+  .app.is-sidebar-collapsed .sidebar {
+    width: 100%;
+    padding: 20px;
+  }
+}
+
+@media (max-width: 768px) {
+  .view {
+    padding: 28px 24px 48px;
+  }
+
+  .topbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .topbar__actions {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .overview-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .plus-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .sidebar {
+    padding: 16px;
+  }
+
+  .language-switch__btn {
+    padding: 6px 10px;
+  }
+
+  .theme-switch,
+  .logout-button {
+    padding: 8px 10px;
+  }
+
+  .view__title {
+    font-size: 1.6rem;
+  }
+}
+
+.analysis-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.analysis-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  padding: 24px;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  position: relative;
+  overflow: hidden;
+}
+
+.analysis-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--color-accent) 12%, transparent),
+    transparent 55%
+  );
+  opacity: 0.55;
+}
+
+.analysis-card h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  position: relative;
+  z-index: 1;
+}
+
+.analysis-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  position: relative;
+  z-index: 1;
+}
+
+.analysis-list li {
+  position: relative;
+  padding-left: 18px;
+  font-size: 0.95rem;
+}
+
+.analysis-list li::before {
+  content: '';
+  position: absolute;
+  top: 8px;
+  left: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 3px;
+  background: var(--color-accent);
+  opacity: 0.65;
+}
+
+@media (max-width: 768px) {
+  .analysis-grid {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+}


### PR DESCRIPTION
## Summary
- align the sidebar with the five module groups from the mock-up and keep hoverable submodule previews
- refresh each main view so the content mirrors the new module focus areas with concise cards and callouts
- streamline the translation/theme/sidebar logic to support the simplified structure in both languages

## Testing
- not run (static frontend)

------
https://chatgpt.com/codex/tasks/task_b_68d119e8bf28832a8fa494c693a09586