### PR TITLE
Restructure ESG navigation to match new module layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,14 @@ Exigences
 
 Bon pilotage RSE avec Ecopilot !
 
+## Prototype d'interface
+
+Une première version statique de l'application est disponible pour prévisualisation rapide.
+
+- Ouvrir directement le fichier `index.html` dans un navigateur moderne pour explorer le prototype.
+- La barre latérale est rétractable (icône ☰) et propose les modules décrits dans les maquettes.
+- Les modules disponibles : Saisie de données, Filtres (BU / Activité / Filiale / Société / Site), Indicateurs ESG, Bilan carbone, Alignement référentiel, Gestion énergie, Rapports RSE et Paramètres.
+- Les bascules thème clair/sombre et langue FR/EN se trouvent dans la barre latérale.
+- Les sous-modules apparaissent au survol de chaque module et sont également listés dans la zone de contenu.
+- Le design est responsive afin de s'adapter aux écrans desktop et mobiles.
+

--- a/app.js
+++ b/app.js
@@ -1,0 +1,937 @@
+const uiText = {
+  fr: {
+    welcomeTitle: 'Bienvenue',
+    welcomeSubtitle: 'Accédez à vos modules RSE en un clin d\'œil.',
+    userRole: 'Responsable RSE',
+    modulesTitle: 'Modules',
+    logout: 'Déconnexion',
+    submodulesTitle: 'Sous-modules clés',
+    highlightTitle: 'Actions principales',
+    kpiTitle: 'KPIs en direct',
+    refresh: 'Actualiser',
+    emptySubmodules: 'Aucun sous-module configuré pour le moment.',
+    emptyHighlights: 'Ajoutez des actions à ce module pour les retrouver ici.',
+    breadcrumbPrefix: 'Pilotage',
+    lastUpdated: 'Dernière mise à jour :',
+    themeLight: 'Mode clair',
+    themeDark: 'Mode sombre',
+    languageToFrench: 'Basculer l\'interface en français',
+    languageToEnglish: 'Switch interface to English',
+    openMenu: 'Ouvrir le menu',
+    closeMenu: 'Fermer le menu',
+    collapseSidebar: 'Réduire la barre latérale',
+    expandSidebar: 'Développer la barre latérale',
+    userGreeting: 'Bienvenue Yassine Bouhlal, voici votre synthèse ESG.'
+  },
+  en: {
+    welcomeTitle: 'Welcome',
+    welcomeSubtitle: 'Access your ESG modules at a glance.',
+    userRole: 'ESG Manager',
+    modulesTitle: 'Modules',
+    logout: 'Log out',
+    submodulesTitle: 'Key sub-modules',
+    highlightTitle: 'Priority actions',
+    kpiTitle: 'Live KPIs',
+    refresh: 'Refresh',
+    emptySubmodules: 'No sub-modules configured yet.',
+    emptyHighlights: 'Add actions to this module to track them here.',
+    breadcrumbPrefix: 'Workspace',
+    lastUpdated: 'Last updated:',
+    themeLight: 'Light mode',
+    themeDark: 'Dark mode',
+    languageToFrench: 'Afficher l\'interface en français',
+    languageToEnglish: 'Switch interface to English',
+    openMenu: 'Open menu',
+    closeMenu: 'Close menu',
+    collapseSidebar: 'Collapse sidebar',
+    expandSidebar: 'Expand sidebar',
+    userGreeting: 'Welcome Yassine Bouhlal, here is your ESG summary.'
+  }
+};
+
+const modules = [
+  {
+    id: 'data-entry',
+    icon: '📝',
+    label: { fr: 'Saisie de données', en: 'Data entry' },
+    tagline: { fr: 'Workflow de collecte', en: 'Collection workflow' },
+    description: {
+      fr: 'Centralisez la collecte de données extra-financières via un workflow guidé.',
+      en: 'Centralise ESG data collection with a guided workflow.'
+    },
+    highlights: [
+      {
+        fr: 'Suivi du workflow Agent → Super User → Admin',
+        en: 'Track the Agent → Super User → Admin workflow'
+      },
+      {
+        fr: 'Temps de saisie estimé : 10 à 20 min/mois',
+        en: 'Estimated input time: 10 to 20 min/month'
+      },
+      {
+        fr: 'Connexion possible avec vos ERP existants',
+        en: 'Connect with existing ERP systems'
+      }
+    ],
+    subModules: [
+      {
+        id: 'agent-entry',
+        label: { fr: 'Agent de saisie', en: 'Data entry agent' },
+        description: {
+          fr: 'Capture des données brutes et pièces justificatives.',
+          en: 'Capture raw data and supporting documents.'
+        }
+      },
+      {
+        id: 'super-user',
+        label: { fr: 'Super User', en: 'Super user validation' },
+        description: {
+          fr: 'Vérifie, corrige et valide les données collectées.',
+          en: 'Reviews, corrects and validates collected data.'
+        }
+      },
+      {
+        id: 'integration',
+        label: { fr: 'Intégration ERP', en: 'ERP integration' },
+        description: {
+          fr: 'Synchronisation automatique avec vos systèmes externes.',
+          en: 'Automatic synchronisation with external systems.'
+        }
+      },
+      {
+        id: 'imports',
+        label: { fr: 'Imports normalisés', en: 'Standardised imports' },
+        description: {
+          fr: 'Importez des fichiers CSV/XLSX harmonisés en quelques clics.',
+          en: 'Import harmonised CSV/XLSX files in a few clicks.'
+        }
+      }
+    ],
+    lastUpdated: '2024-06-12T08:30:00Z'
+  },
+  {
+    id: 'filters',
+    icon: '🎯',
+    label: { fr: 'Filtres', en: 'Filters' },
+    tagline: { fr: 'Affinez vos vues', en: 'Refine your views' },
+    description: {
+      fr: 'Affinez vos analyses par entité, périmètre et période.',
+      en: 'Refine your analytics by entity, scope and period.'
+    },
+    highlights: [
+      {
+        fr: 'Filtrage par Business Unit, Activité, Filiale, Société et Site',
+        en: 'Filter by business unit, activity, subsidiary, company and site'
+      },
+      {
+        fr: 'Sauvegarde de vues personnalisées',
+        en: 'Save personalised views'
+      },
+      {
+        fr: 'Application instantanée sur les rapports et tableaux de bord',
+        en: 'Instant application on reports and dashboards'
+      }
+    ],
+    subModules: [
+      {
+        id: 'filter-bu',
+        label: { fr: 'Business Unit', en: 'Business unit' },
+        description: {
+          fr: 'Comparez vos performances par ligne d’activité.',
+          en: 'Compare performance by line of business.'
+        }
+      },
+      {
+        id: 'filter-activity',
+        label: { fr: 'Activité', en: 'Activity' },
+        description: {
+          fr: 'Analysez les indicateurs selon vos métiers.',
+          en: 'Analyse indicators by core activities.'
+        }
+      },
+      {
+        id: 'filter-entity',
+        label: { fr: 'Filiale', en: 'Subsidiary' },
+        description: {
+          fr: 'Suivez la contribution de chaque entité.',
+          en: 'Track each legal entity’s contribution.'
+        }
+      },
+      {
+        id: 'filter-company',
+        label: { fr: 'Société', en: 'Company' },
+        description: {
+          fr: 'Analysez vos KPIs par société légale ou groupe.',
+          en: 'Analyse KPIs by legal company or group.'
+        }
+      },
+      {
+        id: 'filter-site',
+        label: { fr: 'Site', en: 'Site' },
+        description: {
+          fr: 'Zoomez sur un site ou une usine spécifique.',
+          en: 'Zoom in on a specific plant or site.'
+        }
+      },
+      {
+        id: 'filter-period',
+        label: { fr: 'Période', en: 'Period' },
+        description: {
+          fr: 'Sélectionnez la période de reporting à comparer.',
+          en: 'Select the reporting period to compare.'
+        }
+      }
+    ],
+    lastUpdated: '2024-06-11T15:10:00Z'
+  },
+  {
+    id: 'indicators-esg',
+    icon: '📊',
+    label: { fr: 'Indicateurs ESG', en: 'ESG indicators' },
+    tagline: { fr: 'Main KPIs', en: 'Main KPIs' },
+    description: {
+      fr: 'Pilotez vos indicateurs environnementaux, sociaux et de gouvernance sur un tableau unifié.',
+      en: 'Steer environmental, social and governance indicators in a unified board.'
+    },
+    highlights: [
+      {
+        fr: 'Vue consolidée E / S / G avec graphiques interactifs',
+        en: 'Consolidated E / S / G view with interactive charts'
+      },
+      {
+        fr: 'Alertes immédiates sur les dérives ESG',
+        en: 'Immediate alerts on ESG drifts'
+      },
+      {
+        fr: 'Comparaisons par référentiel et objectifs internes',
+        en: 'Comparisons against frameworks and internal targets'
+      }
+    ],
+    subModules: [
+      {
+        id: 'esg-e',
+        label: { fr: 'Indicateurs E', en: 'E indicators' },
+        description: {
+          fr: 'Gestion de l’énergie, de l’eau et des déchets.',
+          en: 'Energy, water and waste management.'
+        }
+      },
+      {
+        id: 'esg-s',
+        label: { fr: 'Indicateurs S', en: 'S indicators' },
+        description: {
+          fr: 'Social & sociétal, climat social et capital humain.',
+          en: 'Social & societal, employee climate and human capital.'
+        }
+      },
+      {
+        id: 'esg-g',
+        label: { fr: 'Indicateurs G', en: 'G indicators' },
+        description: {
+          fr: 'Gouvernance, conformité et pilotage des risques.',
+          en: 'Governance, compliance and risk steering.'
+        }
+      },
+      {
+        id: 'esg-dashboards',
+        label: { fr: 'Analyses dynamiques', en: 'Dynamic analytics' },
+        description: {
+          fr: 'KPIs détaillés par BU, société, site et période.',
+          en: 'Detailed KPIs by BU, company, site and period.'
+        }
+      }
+    ],
+    lastUpdated: '2024-06-13T07:45:00Z'
+  },
+  {
+    id: 'carbon-footprint',
+    icon: '🌍',
+    label: { fr: 'Bilan carbone', en: 'Carbon footprint' },
+    tagline: { fr: 'Calcul multi-scopes', en: 'Multi-scope tracking' },
+    description: {
+      fr: 'Quantifiez vos émissions Scopes 1, 2 et 3 et suivez vos plans de réduction.',
+      en: 'Quantify your Scope 1, 2 and 3 emissions and track reduction plans.'
+    },
+    highlights: [
+      {
+        fr: 'Tableau de bord dédié par scope et périmètre',
+        en: 'Dedicated dashboard by scope and boundary'
+      },
+      {
+        fr: 'Facteurs d’émission maintenus à jour automatiquement',
+        en: 'Emission factors kept automatically up to date'
+      },
+      {
+        fr: 'Simulations d’actions et trajectoires bas carbone',
+        en: 'Action simulations and low-carbon trajectories'
+      }
+    ],
+    subModules: [
+      {
+        id: 'carbon-scopes',
+        label: { fr: 'Scopes 1, 2 & 3', en: 'Scopes 1, 2 & 3' },
+        description: {
+          fr: 'Suivi des émissions directes, indirectes et amont/aval.',
+          en: 'Track direct, indirect and upstream/downstream emissions.'
+        }
+      },
+      {
+        id: 'carbon-drivers',
+        label: { fr: 'Facteurs d’émission', en: 'Emission factors' },
+        description: {
+          fr: 'Bibliothèque paramétrable par activité et énergie.',
+          en: 'Configurable library per activity and energy source.'
+        }
+      },
+      {
+        id: 'carbon-scenarios',
+        label: { fr: 'Scénarios & plans d’action', en: 'Scenarios & action plans' },
+        description: {
+          fr: 'Projetez vos réductions et mesurez l’impact des plans.',
+          en: 'Project reductions and measure plan impacts.'
+        }
+      },
+      {
+        id: 'carbon-reporting',
+        label: { fr: 'Reporting réglementaire', en: 'Regulatory reporting' },
+        description: {
+          fr: 'Exports conformes GHG Protocol, BEGES, CSRD.',
+          en: 'Exports compliant with GHG Protocol, BEGES, CSRD.'
+        }
+      }
+    ],
+    lastUpdated: '2024-06-12T18:05:00Z'
+  },
+  {
+    id: 'alignment',
+    icon: '📚',
+    label: { fr: 'Alignement référentiel', en: 'Framework alignment' },
+    tagline: { fr: 'Référentiels & ODD', en: 'Frameworks & SDGs' },
+    description: {
+      fr: 'Cartographiez vos actions aux référentiels GRI, CSRD et ODD.',
+      en: 'Map your actions to the GRI, CSRD and SDG frameworks.'
+    },
+    highlights: [
+      {
+        fr: 'Matrice d’alignement multi-référentiels (GRI, CSRD, ODD)',
+        en: 'Multi-framework alignment matrix (GRI, CSRD, SDGs)'
+      },
+      {
+        fr: 'Suivi des obligations réglementaires par périmètre',
+        en: 'Track regulatory obligations per scope'
+      },
+      {
+        fr: 'Plans d’actions recommandés selon les écarts détectés',
+        en: 'Recommended action plans based on detected gaps'
+      }
+    ],
+    subModules: [
+      {
+        id: 'gri',
+        label: { fr: 'Référentiel GRI', en: 'GRI framework' },
+        description: {
+          fr: 'Visualisez la conformité à chaque indicateur GRI.',
+          en: 'Visualise compliance for each GRI indicator.'
+        }
+      },
+      {
+        id: 'sdg',
+        label: { fr: 'ODD / SDG', en: 'SDGs' },
+        description: {
+          fr: 'Mesurez la contribution aux objectifs de l’ONU.',
+          en: 'Measure contribution to UN goals.'
+        }
+      },
+      {
+        id: 'csrd',
+        label: { fr: 'CSRD', en: 'CSRD' },
+        description: {
+          fr: 'Préparez la conformité aux exigences européennes.',
+          en: 'Prepare compliance with EU requirements.'
+        }
+      },
+      {
+        id: 'action-plan',
+        label: { fr: 'Plans d’actions', en: 'Action plans' },
+        description: {
+          fr: 'Priorisez vos initiatives correctives.',
+          en: 'Prioritise corrective initiatives.'
+        }
+      }
+    ],
+    lastUpdated: '2024-06-07T10:40:00Z'
+  },
+  {
+    id: 'energy-management',
+    icon: '⚡',
+    label: { fr: 'Gestion énergie', en: 'Energy management' },
+    tagline: { fr: 'Optimisation opérationnelle', en: 'Operational optimisation' },
+    description: {
+      fr: 'Optimisez vos consommations d’énergie, d’eau et de ressources sur l’ensemble de vos sites.',
+      en: 'Optimise energy, water and resource consumption across your sites.'
+    },
+    highlights: [
+      {
+        fr: 'Monitoring temps réel des consommations multi-énergies',
+        en: 'Real-time monitoring of multi-energy consumption'
+      },
+      {
+        fr: 'Alertes intelligentes sur les dérives de consommation',
+        en: 'Smart alerts on consumption drifts'
+      },
+      {
+        fr: 'Pilotage des plans d’efficacité énergétique',
+        en: 'Steering of energy efficiency plans'
+      }
+    ],
+    subModules: [
+      {
+        id: 'energy-dashboards',
+        label: { fr: 'Tableaux de bord énergie', en: 'Energy dashboards' },
+        description: {
+          fr: 'Visualisez les consommations par site, BU et période.',
+          en: 'Visualise consumption by site, BU and period.'
+        }
+      },
+      {
+        id: 'energy-water',
+        label: { fr: 'Gestion de l’eau', en: 'Water management' },
+        description: {
+          fr: 'Suivez prélèvements, rejets et conformité réglementaire.',
+          en: 'Track withdrawals, discharges and regulatory compliance.'
+        }
+      },
+      {
+        id: 'energy-waste',
+        label: { fr: 'Gestion des déchets', en: 'Waste management' },
+        description: {
+          fr: 'Mesurez tri, valorisation et coûts associés.',
+          en: 'Measure sorting, recovery and associated costs.'
+        }
+      },
+      {
+        id: 'energy-iot',
+        label: { fr: 'IoT & maintenance', en: 'IoT & maintenance' },
+        description: {
+          fr: 'Connectez vos capteurs pour anticiper les dérives.',
+          en: 'Connect your sensors to anticipate drifts.'
+        }
+      }
+    ],
+    lastUpdated: '2024-06-11T09:30:00Z'
+  },
+  {
+    id: 'rse-report',
+    icon: '📄',
+    label: { fr: 'Rapports RSE', en: 'ESG reports' },
+    tagline: { fr: 'Rapports et analyses', en: 'Reports & analytics' },
+    description: {
+      fr: 'Générez vos rapports extra-financiers, comparatifs et narratifs en quelques clics.',
+      en: 'Generate extra-financial, comparative and narrative reports in a few clicks.'
+    },
+    highlights: [
+      {
+        fr: 'Rapport annuel RSE personnalisable',
+        en: 'Customisable annual ESG report'
+      },
+      {
+        fr: 'Comparatifs automatiques N vs N-1',
+        en: 'Automatic year-over-year comparisons'
+      },
+      {
+        fr: 'Exports PDF, Word et PPT prêts à l’emploi',
+        en: 'PDF, Word and PPT exports ready to use'
+      }
+    ],
+    subModules: [
+      {
+        id: 'report-annual',
+        label: { fr: 'Rapport annuel RSE', en: 'Annual ESG report' },
+        description: {
+          fr: 'Structurez votre rapport selon les référentiels cibles.',
+          en: 'Structure the report according to target frameworks.'
+        }
+      },
+      {
+        id: 'report-performance',
+        label: { fr: 'Tableaux de performance', en: 'Performance tables' },
+        description: {
+          fr: 'Comparez N / N-1 et visualisez les écarts majeurs.',
+          en: 'Compare YoY results and visualise major gaps.'
+        }
+      },
+      {
+        id: 'report-commentary',
+        label: { fr: 'Commentaires & storytelling', en: 'Commentary & storytelling' },
+        description: {
+          fr: 'Ajoutez des analyses qualitatives et plans d’action.',
+          en: 'Add qualitative insights and action plans.'
+        }
+      },
+      {
+        id: 'report-exports',
+        label: { fr: 'Exports multi-formats', en: 'Multi-format exports' },
+        description: {
+          fr: 'Diffusez vos livrables en PDF, Word et PPT.',
+          en: 'Distribute deliverables in PDF, Word and PPT.'
+        }
+      }
+    ],
+    lastUpdated: '2024-06-06T12:15:00Z'
+  },
+  {
+    id: 'settings',
+    icon: '⚙️',
+    label: { fr: 'Paramètres', en: 'Settings' },
+    tagline: { fr: 'Configuration', en: 'Configuration' },
+    description: {
+      fr: 'Administrez les accès, objectifs et notifications de votre organisation.',
+      en: 'Manage access, targets and notifications for your organisation.'
+    },
+    highlights: [
+      {
+        fr: 'Gestion des utilisateurs et rôles',
+        en: 'Manage users and roles'
+      },
+      {
+        fr: 'Paramétrage des objectifs et indicateurs clés',
+        en: 'Configure objectives and key indicators'
+      },
+      {
+        fr: 'Notifications ciblées par profil',
+        en: 'Targeted notifications by profile'
+      }
+    ],
+    subModules: [
+      {
+        id: 'profile',
+        label: { fr: 'Profil', en: 'Profile' },
+        description: {
+          fr: 'Mettez à jour vos informations et préférences.',
+          en: 'Update your information and preferences.'
+        }
+      },
+      {
+        id: 'organisation',
+        label: { fr: 'Organisation', en: 'Organisation' },
+        description: {
+          fr: 'Définissez l’arborescence sites / filiales / BU.',
+          en: 'Define the structure of sites / subsidiaries / BUs.'
+        }
+      },
+      {
+        id: 'subscription',
+        label: { fr: 'Abonnements', en: 'Subscriptions' },
+        description: {
+          fr: 'Pilotez vos accès et modules souscrits.',
+          en: 'Manage access and subscribed modules.'
+        }
+      },
+      {
+        id: 'notifications',
+        label: { fr: 'Notifications', en: 'Notifications' },
+        description: {
+          fr: 'Choisissez vos alertes mails & in-app.',
+          en: 'Select email and in-app alerts.'
+        }
+      },
+      {
+        id: 'objectives',
+        label: { fr: 'Objectifs', en: 'Targets' },
+        description: {
+          fr: 'Créez des objectifs par indicateur et suivez-les.',
+          en: 'Create targets per indicator and track them.'
+        }
+      }
+    ],
+    lastUpdated: '2024-06-03T12:00:00Z'
+  }
+];
+
+const kpis = [
+  {
+    id: 'carbon-kpi',
+    icon: '🌿',
+    value: '-12%',
+    label: { fr: 'Empreinte carbone', en: 'Carbon footprint' },
+    detail: {
+      fr: 'vs N-1 (Scopes 1 & 2)',
+      en: 'vs previous year (Scopes 1 & 2)'
+    },
+    trend: 'positive'
+  },
+  {
+    id: 'energy-kpi',
+    icon: '⚡',
+    value: '245 MWh',
+    label: { fr: 'Énergie optimisée', en: 'Energy optimised' },
+    detail: {
+      fr: 'Économie cumulée',
+      en: 'Cumulative savings'
+    },
+    trend: 'positive'
+  },
+  {
+    id: 'training-kpi',
+    icon: '🎓',
+    value: '92%',
+    label: { fr: 'Formation complétée', en: 'Training completion' },
+    detail: {
+      fr: 'Collaborateurs formés',
+      en: 'Employees trained'
+    },
+    trend: 'neutral'
+  },
+  {
+    id: 'ethics-kpi',
+    icon: '🛡️',
+    value: '0',
+    label: { fr: 'Incidents d’éthique', en: 'Ethics incidents' },
+    detail: {
+      fr: 'Déclarés ce trimestre',
+      en: 'Reported this quarter'
+    },
+    trend: 'positive'
+  }
+];
+
+const elements = {
+  body: document.body,
+  sidebar: document.getElementById('sidebar'),
+  sidebarBackdrop: document.getElementById('sidebarBackdrop'),
+  moduleList: document.getElementById('moduleList'),
+  sidebarToggle: document.getElementById('sidebarToggle'),
+  mobileSidebarToggle: document.getElementById('mobileSidebarToggle'),
+  themeToggle: document.getElementById('themeToggle'),
+  languageToggle: document.getElementById('languageToggle'),
+  contentTitle: document.getElementById('contentTitle'),
+  contentDescription: document.getElementById('contentDescription'),
+  contentBreadcrumb: document.getElementById('contentBreadcrumb'),
+  contentGreeting: document.getElementById('contentGreeting'),
+  submoduleGrid: document.getElementById('submoduleGrid'),
+  highlightList: document.getElementById('highlightList'),
+  kpiGrid: document.getElementById('kpiGrid'),
+  contentUpdate: document.getElementById('contentUpdate'),
+  refreshButton: document.getElementById('refreshButton')
+};
+
+const state = {
+  language: 'fr',
+  theme: 'light',
+  sidebarCollapsed: false,
+  activeModuleId: modules.find((module) => module.id === 'indicators-esg')?.id ?? modules[0]?.id ?? null,
+  lastUpdated: new Date()
+};
+
+function init() {
+  hydratePreferences();
+  renderModuleList();
+  renderKpis();
+  updateStaticTexts();
+  updateThemeToggle();
+  updateLanguageToggle();
+  updateContent();
+  updateSidebarState();
+  updateMobileToggle();
+  updateTimestamp();
+  bindEvents();
+}
+
+function hydratePreferences() {
+  const storedLanguage = window.localStorage?.getItem('ecopilot-lang');
+  const storedTheme = window.localStorage?.getItem('ecopilot-theme');
+  if (storedLanguage && (storedLanguage === 'fr' || storedLanguage === 'en')) {
+    state.language = storedLanguage;
+    document.body.dataset.language = storedLanguage;
+  }
+  if (storedTheme && (storedTheme === 'light' || storedTheme === 'dark')) {
+    state.theme = storedTheme;
+  } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    state.theme = 'dark';
+  }
+  document.body.dataset.theme = state.theme;
+}
+
+function bindEvents() {
+  elements.sidebarToggle.addEventListener('click', () => toggleSidebar());
+  elements.mobileSidebarToggle.addEventListener('click', () => toggleSidebar(false));
+  elements.sidebarBackdrop.addEventListener('click', () => toggleSidebar(true));
+  elements.themeToggle.addEventListener('click', toggleTheme);
+  elements.languageToggle.addEventListener('click', toggleLanguage);
+  elements.refreshButton.addEventListener('click', handleRefresh);
+  window.addEventListener('resize', updateMobileToggle);
+}
+
+function renderModuleList() {
+  elements.moduleList.innerHTML = '';
+  modules.forEach((module) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = `module-item${module.id === state.activeModuleId ? ' active' : ''}`;
+    button.dataset.id = module.id;
+    button.setAttribute('aria-label', module.label[state.language]);
+
+    const icon = document.createElement('span');
+    icon.className = 'module-icon';
+    icon.textContent = module.icon;
+
+    const textWrapper = document.createElement('span');
+    textWrapper.className = 'module-text';
+
+    const label = document.createElement('span');
+    label.className = 'module-label';
+    label.textContent = module.label[state.language];
+
+    const tagline = document.createElement('span');
+    tagline.className = 'module-tagline';
+    tagline.textContent = module.tagline?.[state.language] ?? '';
+
+    textWrapper.append(label, tagline);
+    button.append(icon, textWrapper);
+
+    if (Array.isArray(module.subModules) && module.subModules.length) {
+      const popover = document.createElement('div');
+      popover.className = 'submodule-popover';
+      const list = document.createElement('ul');
+
+      module.subModules.forEach((subModule) => {
+        const listItem = document.createElement('li');
+        const title = document.createElement('strong');
+        title.textContent = subModule.label[state.language];
+        listItem.appendChild(title);
+        if (subModule.description) {
+          const desc = document.createElement('span');
+          desc.textContent = subModule.description[state.language];
+          listItem.appendChild(desc);
+        }
+        list.appendChild(listItem);
+      });
+
+      popover.appendChild(list);
+      button.appendChild(popover);
+    }
+
+    button.addEventListener('click', () => {
+      if (state.activeModuleId !== module.id) {
+        state.activeModuleId = module.id;
+        updateContent();
+        renderModuleList();
+      }
+      if (window.matchMedia('(max-width: 900px)').matches) {
+        toggleSidebar(true);
+      }
+    });
+
+    elements.moduleList.appendChild(button);
+  });
+}
+
+function renderKpis() {
+  elements.kpiGrid.innerHTML = '';
+  kpis.forEach((kpi) => {
+    const card = document.createElement('article');
+    card.className = `kpi-card ${kpi.trend}`;
+
+    const header = document.createElement('div');
+    header.className = 'kpi-header';
+
+    const icon = document.createElement('span');
+    icon.className = 'kpi-icon';
+    icon.textContent = kpi.icon;
+
+    const label = document.createElement('span');
+    label.className = 'kpi-label';
+    label.textContent = kpi.label[state.language];
+
+    header.append(icon, label);
+
+    const value = document.createElement('span');
+    value.className = 'kpi-value';
+    value.textContent = kpi.value;
+
+    const trend = document.createElement('span');
+    trend.className = 'kpi-trend';
+    trend.textContent = kpi.detail[state.language];
+
+    card.append(header, value, trend);
+    elements.kpiGrid.appendChild(card);
+  });
+}
+
+function updateContent() {
+  const activeModule = modules.find((module) => module.id === state.activeModuleId) ?? modules[0];
+  if (!activeModule) return;
+
+  elements.contentTitle.textContent = activeModule.label[state.language];
+  elements.contentDescription.textContent = activeModule.description[state.language];
+  elements.contentBreadcrumb.textContent = `${uiText[state.language].breadcrumbPrefix} · ${activeModule.label[state.language]}`;
+  elements.contentGreeting.textContent = uiText[state.language].userGreeting;
+
+  renderSubModules(activeModule);
+  renderHighlights(activeModule);
+  updateTimestamp(activeModule.lastUpdated);
+}
+
+function renderSubModules(activeModule) {
+  elements.submoduleGrid.innerHTML = '';
+  if (!activeModule.subModules || !activeModule.subModules.length) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.textContent = uiText[state.language].emptySubmodules;
+    elements.submoduleGrid.appendChild(empty);
+    return;
+  }
+
+  activeModule.subModules.forEach((subModule) => {
+    const card = document.createElement('article');
+    card.className = 'submodule-card';
+
+    const title = document.createElement('h3');
+    title.textContent = subModule.label[state.language];
+
+    const description = document.createElement('p');
+    description.textContent = subModule.description?.[state.language] ?? '';
+
+    card.append(title, description);
+    elements.submoduleGrid.appendChild(card);
+  });
+}
+
+function renderHighlights(activeModule) {
+  elements.highlightList.innerHTML = '';
+  if (!activeModule.highlights || !activeModule.highlights.length) {
+    const empty = document.createElement('li');
+    empty.className = 'empty-state';
+    empty.textContent = uiText[state.language].emptyHighlights;
+    elements.highlightList.appendChild(empty);
+    return;
+  }
+
+  activeModule.highlights.forEach((highlight) => {
+    const item = document.createElement('li');
+    item.textContent = highlight[state.language];
+    elements.highlightList.appendChild(item);
+  });
+}
+
+function updateStaticTexts() {
+  document.querySelectorAll('[data-i18n]').forEach((element) => {
+    const key = element.getAttribute('data-i18n');
+    const translation = uiText[state.language][key];
+    if (translation) {
+      element.textContent = translation;
+    }
+  });
+}
+
+function updateThemeToggle() {
+  const label = elements.themeToggle.querySelector('.label');
+  const icon = elements.themeToggle.querySelector('.icon');
+  if (state.theme === 'dark') {
+    icon.textContent = '🌞';
+    label.textContent = uiText[state.language].themeLight;
+  } else {
+    icon.textContent = '🌙';
+    label.textContent = uiText[state.language].themeDark;
+  }
+}
+
+function updateLanguageToggle() {
+  const label = elements.languageToggle.querySelector('.label');
+  const icon = elements.languageToggle.querySelector('.icon');
+  if (state.language === 'fr') {
+    icon.textContent = '🇫🇷';
+    label.textContent = 'FR';
+    elements.languageToggle.setAttribute('aria-label', uiText.fr.languageToEnglish);
+    elements.languageToggle.setAttribute('title', uiText.fr.languageToEnglish);
+  } else {
+    icon.textContent = '🇬🇧';
+    label.textContent = 'EN';
+    elements.languageToggle.setAttribute('aria-label', uiText.en.languageToFrench);
+    elements.languageToggle.setAttribute('title', uiText.en.languageToFrench);
+  }
+}
+
+function updateTimestamp(lastUpdatedFromModule) {
+  if (lastUpdatedFromModule) {
+    state.lastUpdated = new Date(lastUpdatedFromModule);
+  }
+  const formatted = new Intl.DateTimeFormat(state.language === 'fr' ? 'fr-FR' : 'en-GB', {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(state.lastUpdated);
+  elements.contentUpdate.textContent = `${uiText[state.language].lastUpdated} ${formatted}`;
+}
+
+function toggleTheme() {
+  state.theme = state.theme === 'light' ? 'dark' : 'light';
+  document.body.dataset.theme = state.theme;
+  window.localStorage?.setItem('ecopilot-theme', state.theme);
+  updateThemeToggle();
+}
+
+function toggleLanguage() {
+  state.language = state.language === 'fr' ? 'en' : 'fr';
+  document.body.dataset.language = state.language;
+  window.localStorage?.setItem('ecopilot-lang', state.language);
+  updateStaticTexts();
+  renderModuleList();
+  renderKpis();
+  updateThemeToggle();
+  updateLanguageToggle();
+  updateContent();
+  updateSidebarState();
+}
+
+function toggleSidebar(forceCollapse) {
+  if (typeof forceCollapse === 'boolean') {
+    state.sidebarCollapsed = forceCollapse;
+  } else {
+    state.sidebarCollapsed = !state.sidebarCollapsed;
+  }
+  updateSidebarState();
+}
+
+function updateSidebarState() {
+  const isMobile = window.matchMedia('(max-width: 900px)').matches;
+  elements.sidebar.classList.toggle('collapsed', state.sidebarCollapsed);
+
+  elements.sidebarBackdrop.classList.toggle('visible', isMobile && !state.sidebarCollapsed);
+
+  const sidebarLabelKey = state.sidebarCollapsed ? 'expandSidebar' : 'collapseSidebar';
+  elements.sidebarToggle.setAttribute('aria-label', uiText[state.language][sidebarLabelKey]);
+  elements.sidebarToggle.setAttribute('title', uiText[state.language][sidebarLabelKey]);
+
+  updateMobileToggle();
+}
+
+function updateMobileToggle() {
+  const isMobile = window.matchMedia('(max-width: 900px)').matches;
+  if (!isMobile) {
+    elements.mobileSidebarToggle.setAttribute('aria-hidden', 'true');
+    elements.mobileSidebarToggle.style.visibility = 'hidden';
+    elements.mobileSidebarToggle.style.pointerEvents = 'none';
+    return;
+  }
+  elements.mobileSidebarToggle.setAttribute('aria-hidden', 'false');
+  elements.mobileSidebarToggle.style.visibility = 'visible';
+  elements.mobileSidebarToggle.style.pointerEvents = 'auto';
+  const ariaKey = state.sidebarCollapsed ? 'openMenu' : 'closeMenu';
+  elements.mobileSidebarToggle.setAttribute('aria-label', uiText[state.language][ariaKey]);
+  elements.mobileSidebarToggle.setAttribute('title', uiText[state.language][ariaKey]);
+  const iconSpan = elements.mobileSidebarToggle.querySelector('.icon');
+  iconSpan.textContent = state.sidebarCollapsed ? '☰' : '✕';
+}
+
+function handleRefresh() {
+  state.lastUpdated = new Date();
+  const activeModule = modules.find((module) => module.id === state.activeModuleId);
+  if (activeModule) {
+    activeModule.lastUpdated = state.lastUpdated.toISOString();
+  }
+  updateTimestamp(state.lastUpdated);
+  elements.refreshButton.classList.add('is-pressed');
+  setTimeout(() => elements.refreshButton.classList.remove('is-pressed'), 250);
+}
+
+init();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>EcoPilot • Tableau de bord RSE</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body data-theme="light" data-language="fr">
+    <div class="app-shell">
+      <aside class="sidebar" id="sidebar" aria-label="Navigation principale">
+        <div class="sidebar-top">
+          <button
+            class="icon-button"
+            id="sidebarToggle"
+            type="button"
+            aria-label="Réduire la barre latérale"
+          >
+            <span class="icon">☰</span>
+          </button>
+          <div class="brand">
+            <span class="brand-mark">eco</span>
+            <span class="brand-name">EcoPilot</span>
+          </div>
+        </div>
+        <div class="sidebar-quick-actions">
+          <button class="pill-button" id="themeToggle" type="button">
+            <span class="icon" aria-hidden="true">🌙</span>
+            <span class="label" data-i18n="themeDark">Mode sombre</span>
+          </button>
+          <button class="pill-button ghost" id="languageToggle" type="button">
+            <span class="icon" aria-hidden="true">🇫🇷</span>
+            <span class="label">FR</span>
+          </button>
+        </div>
+        <section class="sidebar-section user-block">
+          <h2 class="section-title" data-i18n="welcomeTitle">Bienvenue</h2>
+          <p class="section-subtitle" data-i18n="welcomeSubtitle">
+            Accédez à vos modules RSE en un clin d'œil.
+          </p>
+          <div class="user-card">
+            <div class="user-avatar" aria-hidden="true">YB</div>
+            <div class="user-info">
+              <p class="user-name">Yassine Bouhlal</p>
+              <p class="user-role" data-i18n="userRole">Responsable RSE</p>
+            </div>
+          </div>
+        </section>
+        <section class="sidebar-section">
+          <h2 class="section-title" data-i18n="modulesTitle">Modules</h2>
+          <nav class="module-list" id="moduleList"></nav>
+        </section>
+        <section class="sidebar-section">
+          <button class="pill-button ghost full" id="logoutButton" type="button">
+            <span class="icon" aria-hidden="true">⎋</span>
+            <span data-i18n="logout">Déconnexion</span>
+          </button>
+        </section>
+      </aside>
+      <div class="sidebar-backdrop" id="sidebarBackdrop" tabindex="-1"></div>
+      <main class="main-content" id="mainContent">
+        <header class="content-header">
+          <div class="header-left">
+            <button
+              class="icon-button mobile-toggle"
+              id="mobileSidebarToggle"
+              type="button"
+              aria-label="Ouvrir le menu"
+            >
+              <span class="icon">☰</span>
+            </button>
+            <div class="header-texts">
+              <p class="breadcrumb" id="contentBreadcrumb">Pilotage · Indicateurs ESG</p>
+              <h1 class="content-title" id="contentTitle">Indicateurs ESG</h1>
+              <p class="module-description" id="contentDescription">
+                Pilotez vos indicateurs environnementaux, sociaux et de gouvernance sur un tableau unifié.
+              </p>
+            </div>
+          </div>
+          <div class="header-right">
+            <p class="greeting" id="contentGreeting">
+              Bienvenue Yassine Bouhlal, voici votre synthèse ESG.
+            </p>
+            <span class="update-badge" id="contentUpdate">Dernière mise à jour : —</span>
+          </div>
+        </header>
+        <section class="content-section" aria-labelledby="submodulesTitle">
+          <div class="section-header">
+            <h2 class="section-title" id="submodulesTitle" data-i18n="submodulesTitle">
+              Sous-modules clés
+            </h2>
+          </div>
+          <div class="submodule-grid" id="submoduleGrid"></div>
+        </section>
+        <section class="content-section" aria-labelledby="highlightTitle">
+          <div class="section-header">
+            <h2 class="section-title" id="highlightTitle" data-i18n="highlightTitle">
+              Actions principales
+            </h2>
+          </div>
+          <ul class="highlight-list" id="highlightList"></ul>
+        </section>
+        <section class="content-section" aria-labelledby="kpiTitle">
+          <div class="section-header with-action">
+            <h2 class="section-title" id="kpiTitle" data-i18n="kpiTitle">KPIs en direct</h2>
+            <button class="pill-button ghost" id="refreshButton" type="button">
+              <span class="icon" aria-hidden="true">⟳</span>
+              <span class="label" data-i18n="refresh">Actualiser</span>
+            </button>
+          </div>
+          <div class="kpi-grid" id="kpiGrid"></div>
+        </section>
+      </main>
+    </div>
+    <script src="app.js" defer></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,789 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --color-bg: #f5f7fb;
+  --color-surface: #ffffff;
+  --color-border: #e2e8f0;
+  --color-text-primary: #1f2937;
+  --color-text-secondary: #5b677a;
+  --color-accent: #2a9d8f;
+  --color-accent-soft: rgba(42, 157, 143, 0.12);
+  --color-positive: #2a9d8f;
+  --color-negative: #e76f51;
+  --color-neutral: #f4a261;
+  --shadow-lg: 0 24px 60px rgba(15, 23, 42, 0.18);
+  --shadow-md: 0 16px 40px rgba(15, 23, 42, 0.12);
+  --shadow-sm: 0 10px 24px rgba(15, 23, 42, 0.08);
+  --sidebar-width: 320px;
+  --sidebar-collapsed-width: 76px;
+  --transition-base: 0.28s ease;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body[data-theme='dark'] {
+  --color-bg: #0f172a;
+  --color-surface: #131f3a;
+  --color-border: #1f2a44;
+  --color-text-primary: #e2e8f0;
+  --color-text-secondary: #94a3b8;
+  --color-accent-soft: rgba(42, 157, 143, 0.18);
+  --shadow-lg: 0 24px 60px rgba(2, 6, 23, 0.5);
+  --shadow-md: 0 16px 40px rgba(2, 6, 23, 0.4);
+  --shadow-sm: 0 10px 24px rgba(2, 6, 23, 0.32);
+}
+
+html,
+body {
+  min-height: 100%;
+}
+
+body {
+  background: var(--color-bg);
+  color: var(--color-text-primary);
+  font-family: inherit;
+  -webkit-font-smoothing: antialiased;
+  transition: background var(--transition-base), color var(--transition-base);
+}
+
+button {
+  font-family: inherit;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.app-shell {
+  display: flex;
+  align-items: stretch;
+  min-height: 100vh;
+  overflow: hidden;
+}
+
+.sidebar {
+  width: var(--sidebar-width);
+  background: var(--color-surface);
+  border-right: 1px solid var(--color-border);
+  padding: 28px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  transition: width var(--transition-base), transform var(--transition-base),
+    box-shadow var(--transition-base);
+  position: relative;
+  z-index: 5;
+  min-height: 100vh;
+  overflow-y: auto;
+  overflow-x: visible;
+  box-shadow: var(--shadow-sm);
+}
+
+.sidebar::-webkit-scrollbar {
+  width: 6px;
+}
+
+.sidebar::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.35);
+  border-radius: 999px;
+}
+
+body[data-theme='dark'] .sidebar {
+  box-shadow: none;
+}
+
+.sidebar.collapsed {
+  width: var(--sidebar-collapsed-width);
+}
+
+.sidebar-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: 0.02em;
+}
+
+.brand-mark {
+  background: var(--color-accent);
+  color: #fff;
+  padding: 6px 10px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.sidebar-quick-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sidebar-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.section-title {
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-text-secondary);
+}
+
+.section-subtitle {
+  font-size: 0.9rem;
+  line-height: 1.4;
+  color: var(--color-text-secondary);
+}
+
+.user-card {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px;
+  border-radius: 18px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+}
+
+body[data-theme='dark'] .user-card {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.user-avatar {
+  width: 46px;
+  height: 46px;
+  border-radius: 16px;
+  background: var(--color-accent);
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.user-name {
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.user-role {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.module-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.module-item {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--color-text-primary);
+  transition: background var(--transition-base), color var(--transition-base),
+    transform var(--transition-base), box-shadow var(--transition-base);
+  position: relative;
+  text-align: left;
+}
+
+.module-item .module-icon {
+  font-size: 1.2rem;
+  flex-shrink: 0;
+}
+
+.module-item .module-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.module-item .module-label {
+  font-weight: 600;
+  font-size: 0.98rem;
+}
+
+.module-item .module-tagline {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-secondary);
+}
+
+.module-item:hover,
+.module-item:focus-visible {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  transform: translateX(4px);
+}
+
+.module-item:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 3px;
+}
+
+.module-item.active {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  box-shadow: var(--shadow-sm);
+}
+
+.module-item.active .module-tagline {
+  color: var(--color-accent);
+}
+
+.submodule-popover {
+  position: absolute;
+  top: 50%;
+  left: calc(100% + 12px);
+  transform: translateY(-50%);
+  background: var(--color-surface);
+  border-radius: 16px;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-lg);
+  padding: 16px;
+  min-width: 220px;
+  display: none;
+  z-index: 20;
+}
+
+.submodule-popover ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.submodule-popover li {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  line-height: 1.35;
+}
+
+.submodule-popover li strong {
+  display: block;
+  color: var(--color-text-primary);
+  margin-bottom: 4px;
+}
+
+.module-item:hover .submodule-popover,
+.module-item:focus-within .submodule-popover {
+  display: flex;
+}
+
+.sidebar.collapsed .module-item {
+  justify-content: center;
+  padding: 12px;
+}
+
+.sidebar.collapsed .module-item .module-text,
+.sidebar.collapsed .sidebar-quick-actions,
+.sidebar.collapsed .sidebar-section .section-title,
+.sidebar.collapsed .sidebar-section .section-subtitle,
+.sidebar.collapsed .user-card,
+.sidebar.collapsed .pill-button.full .label {
+  display: none;
+}
+
+.sidebar.collapsed .module-item:hover .submodule-popover,
+.sidebar.collapsed .module-item:focus-within .submodule-popover {
+  left: calc(100% + 20px);
+}
+
+.sidebar.collapsed .pill-button.full {
+  justify-content: center;
+}
+
+.pill-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 18px;
+  border-radius: 999px;
+  background: var(--color-accent);
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 600;
+  transition: background var(--transition-base), transform var(--transition-base),
+    box-shadow var(--transition-base);
+}
+
+.pill-button .icon {
+  font-size: 1rem;
+}
+
+.pill-button:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
+}
+
+.pill-button.is-pressed {
+  transform: translateY(1px);
+  opacity: 0.85;
+}
+
+.pill-button.ghost {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-primary);
+}
+
+.pill-button.ghost:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.pill-button.full {
+  width: 100%;
+  justify-content: center;
+}
+
+body[data-theme='dark'] .pill-button.ghost {
+  border-color: rgba(148, 163, 184, 0.35);
+  color: var(--color-text-secondary);
+}
+
+body[data-theme='dark'] .pill-button.ghost:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.icon-button {
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 14px;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-primary);
+  background: transparent;
+  transition: background var(--transition-base), color var(--transition-base),
+    border-color var(--transition-base), transform var(--transition-base);
+}
+
+.icon-button .icon {
+  font-size: 1.1rem;
+}
+
+.icon-button:hover {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+  transform: translateY(-1px);
+}
+
+.icon-button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 3px;
+}
+
+.mobile-toggle {
+  display: none;
+}
+
+.sidebar-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition-base);
+  z-index: 4;
+}
+
+.sidebar-backdrop.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.main-content {
+  flex: 1;
+  padding: 36px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.content-header {
+  background: var(--color-surface);
+  border-radius: 28px;
+  padding: 28px;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  justify-content: space-between;
+  align-items: stretch;
+  gap: 24px;
+}
+
+.header-left {
+  display: flex;
+  align-items: flex-start;
+  gap: 18px;
+  flex: 1;
+}
+
+.header-texts {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.breadcrumb {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-text-secondary);
+}
+
+.content-title {
+  font-size: 1.9rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.module-description {
+  font-size: 1rem;
+  line-height: 1.55;
+  color: var(--color-text-secondary);
+  max-width: 640px;
+}
+
+.header-right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 12px;
+  min-width: 240px;
+}
+
+.greeting {
+  font-size: 0.95rem;
+  color: var(--color-text-secondary);
+  text-align: right;
+}
+
+.update-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-radius: 999px;
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.content-section {
+  background: var(--color-surface);
+  border-radius: 28px;
+  padding: 24px;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.section-header.with-action {
+  gap: 16px;
+}
+
+.submodule-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.submodule-card {
+  border: 1px solid var(--color-border);
+  border-radius: 20px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: var(--color-bg);
+  transition: transform var(--transition-base), box-shadow var(--transition-base),
+    border-color var(--transition-base);
+}
+
+body[data-theme='dark'] .submodule-card {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.submodule-card h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.submodule-card p {
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+
+.submodule-card:hover {
+  transform: translateY(-3px);
+  border-color: var(--color-accent);
+  box-shadow: var(--shadow-sm);
+}
+
+.highlight-list {
+  list-style: none;
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.highlight-list li {
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  padding: 14px 18px;
+  background: var(--color-bg);
+  color: var(--color-text-secondary);
+  font-size: 0.92rem;
+  line-height: 1.45;
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  position: relative;
+}
+
+.highlight-list li::before {
+  content: '•';
+  color: var(--color-accent);
+  font-size: 1.6rem;
+  line-height: 1;
+  margin-top: 2px;
+}
+
+body[data-theme='dark'] .highlight-list li,
+body[data-theme='dark'] .kpi-card {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.kpi-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.kpi-card {
+  border: 1px solid var(--color-border);
+  border-radius: 22px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: var(--color-bg);
+  transition: transform var(--transition-base), box-shadow var(--transition-base),
+    border-color var(--transition-base);
+}
+
+.kpi-card:hover {
+  transform: translateY(-3px);
+  border-color: var(--color-accent);
+  box-shadow: var(--shadow-sm);
+}
+
+.kpi-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.kpi-icon {
+  font-size: 1.4rem;
+}
+
+.kpi-label {
+  font-size: 0.92rem;
+  color: var(--color-text-secondary);
+}
+
+.kpi-value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.kpi-trend {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.kpi-card.positive .kpi-value {
+  color: var(--color-positive);
+}
+
+.kpi-card.negative .kpi-value {
+  color: var(--color-negative);
+}
+
+.kpi-card.neutral .kpi-value {
+  color: var(--color-text-primary);
+}
+
+.kpi-card.positive .kpi-trend::before {
+  content: '▲';
+  color: var(--color-positive);
+}
+
+.kpi-card.negative .kpi-trend::before {
+  content: '▼';
+  color: var(--color-negative);
+}
+
+.kpi-card.neutral .kpi-trend::before {
+  content: '▬';
+  color: var(--color-neutral);
+}
+
+.empty-state {
+  border: 1px dashed var(--color-border);
+  border-radius: 18px;
+  padding: 18px;
+  text-align: center;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 1180px) {
+  .main-content {
+    padding: 32px;
+  }
+
+  .content-header,
+  .content-section {
+    border-radius: 24px;
+  }
+}
+
+@media (max-width: 1024px) {
+  .app-shell {
+    flex-direction: row;
+  }
+
+  .main-content {
+    padding: 28px;
+  }
+
+  .header-right {
+    min-width: unset;
+  }
+}
+
+@media (max-width: 900px) {
+  .app-shell {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100%;
+    transform: translateX(0);
+    box-shadow: var(--shadow-lg);
+  }
+
+  .sidebar.collapsed {
+    transform: translateX(-110%);
+    box-shadow: none;
+  }
+
+  .main-content {
+    margin: 0;
+    padding: 92px 20px 32px;
+    max-width: 100%;
+  }
+
+  .content-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .header-left {
+    width: 100%;
+  }
+
+  .header-right {
+    width: 100%;
+    align-items: flex-start;
+  }
+
+  .greeting {
+    text-align: left;
+  }
+
+  .mobile-toggle {
+    display: inline-flex;
+  }
+
+  .submodule-popover {
+    display: none !important;
+  }
+}
+
+@media (max-width: 680px) {
+  .submodule-grid,
+  .highlight-list,
+  .kpi-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .content-title {
+    font-size: 1.6rem;
+  }
+
+  .module-description {
+    font-size: 0.95rem;
+  }
+}
+
+@media (max-width: 420px) {
+  .pill-button {
+    padding: 8px 14px;
+  }
+
+  .content-header,
+  .content-section {
+    padding: 20px;
+  }
+
+  .main-content {
+    padding: 88px 16px 28px;
+  }
+}


### PR DESCRIPTION
## Summary
- regroup the environmental, social and governance sections into a single Indicateurs ESG module with updated content
- add a dedicated Bilan carbone module, rename Alignement référentiel, and introduce Gestion énergie alongside revised Rapports RSE
- include the Société filter and default the dashboard to the Indicateurs ESG view with refreshed header copy

## Testing
- not run (static prototype)

------
https://chatgpt.com/codex/tasks/task_b_68d1621f6434832aa9f77a17c998de9f